### PR TITLE
Add Fractures — reveal timeline documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The 10,000 Miberas and their temporal identities.
 - [All Miberas](miberas/README.md) — Individual entries with full metadata
 - [Grails](grails/README.md) — 42 hand-drawn 1/1 art pieces
 - [Birthdays](birthdays/README.md) — 9,995 unique birthdays spanning 15,000 years
+- [Fractures](fractures/README.md) — 10 reveal phases from sealed envelope to final form
 
 ### VI. The Mechanics
 - [Ranking & Scoring](traits/overlays/ranking/README.md) — Swag Score and tribal coherence

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -84,6 +84,17 @@
   * [19th Century](birthdays/19th-century.md)
   * [20th Century](birthdays/20th-century.md)
   * [21st Century](birthdays/21st-century.md)
+* [Fractures — Reveal Timeline](fractures/README.md)
+  * [MiParcels](fractures/miparcels.md)
+  * [Miladies](fractures/miladies.md)
+  * [MiReveal #1.1](fractures/mireveal-1.1.md)
+  * [MiReveal #2.2](fractures/mireveal-2.2.md)
+  * [MiReveal #3.3](fractures/mireveal-3.3.md)
+  * [MiReveal #4.20](fractures/mireveal-4.20.md)
+  * [MiReveal #5.5](fractures/mireveal-5.5.md)
+  * [MiReveal #6.9](fractures/mireveal-6.9.md)
+  * [MiReveal #7.7](fractures/mireveal-7.7.md)
+  * [MiReveal #8.8](fractures/mireveal-8.8.md)
 
 ## VI. The Ecosystem
 * [Featured Projects & Partners](special-collections/README.md)

--- a/fractures/README.md
+++ b/fractures/README.md
@@ -1,0 +1,57 @@
+<!-- codex-status: COMPLETE | entities: 10 | last-verified: 2026-02-18 -->
+# Fractures — The Reveal Timeline
+
+*10 soulbound collections marking each phase of Mibera's emergence into the world.*
+
+---
+
+## Overview
+
+FracturedMibera is a set of 10 soulbound ERC-721 collections on Berachain. Each represents a reveal phase — a step in the progression from sealed envelope to fully-realized Mibera. They serve as permanent on-chain proof of which reveal wave a holder participated in.
+
+Every Mibera holder can mint their corresponding token ID in each Fracture collection. The tokens are non-transferable — permanently bound to the minting wallet as a record of presence.
+
+## The Reveal Phases
+
+The reveal unfolds in 10 stages. The first two phases — MiParcels and Miladies — are conceptual predecessors: pure anticipation and a nod to lineage. The remaining eight are the progressive unveiling of the Mibera form.
+
+| # | Phase | Symbol | What's Revealed |
+|---|-------|--------|-----------------|
+| 1 | [MiParcels](miparcels.md) | MIPARCEL | Sealed envelopes — labels, stickers, lore scrawl |
+| 2 | [Miladies](miladies.md) | MILADIES | Flipped Milady Maker art with toilet graffiti |
+| 3 | [MiReveal #1.1](mireveal-1.1.md) | MIREVEAL1.1 | Colors and scenery — first hints, rare foregrounds |
+| 4 | [MiReveal #2.2](mireveal-2.2.md) | MIREVEAL2.2 | Scene clears, molecule placed, silhouette appears |
+| 5 | [MiReveal #3.3](mireveal-3.3.md) | MIREVEAL3.3 | Form takes shape, astrology revealed, eyes closed |
+| 6 | [MiReveal #4.20](mireveal-4.20.md) | MIREVEAL4.20 | Moon appears, hat placed if applicable |
+| 7 | [MiReveal #5.5](mireveal-5.5.md) | MIREVEAL5.5 | Mibera awakes — rising sign, face finalized |
+| 8 | [MiReveal #6.9](mireveal-6.9.md) | MIREVEAL6.9 | Head takes final form, ancient emblem appears |
+| 9 | [MiReveal #7.7](mireveal-7.7.md) | MIREVEAL7.7 | Tattoos added — calm before the storm |
+| 10 | [MiReveal #8.8](mireveal-8.8.md) | MIREVEAL8.8 | Final reveal — the current Mibera collection |
+
+### The Naming Convention
+
+The decimal numbering is playful and intentional: 1.1, 2.2, 3.3, **4.20**, 5.5, **6.9**, 7.7, 8.8. The cultural references in 4.20 and 6.9 are deliberate.
+
+## Contracts
+
+All 10 Fracture collections are soulbound ERC-721 contracts on Berachain, deployed from a single script. Token IDs mirror the main Mibera collection 1:1.
+
+| # | Name | Contract |
+|---|------|----------|
+| 1 | MiParcels | `0x6956dae88C00372B1A0b2dfBfE5Eed19F85b0D4B` |
+| 2 | Miladies | `0x8D4972bd5D2df474e71da6676a365fB549853991` |
+| 3 | MiReveal #1.1 | `0x77ec6B83495974a5B2C5BEf943b0f2e5aCd8Fc26` |
+| 4 | MiReveal #2.2 | `0xc557Bf6C7d21BA98A40dDfE2BEAbA682C49D17A9` |
+| 5 | MiReveal #3.3 | `0xbcb082bB41E892f29d9c600eaadEA698d5f712Ef` |
+| 6 | MiReveal #4.20 | `0x2030f226Bf9a0c88687e83AcCdcEfb7Dae260094` |
+| 7 | MiReveal #5.5 | `0xcc426F9375c5edcef5CA6bDb0449c07113348cF7` |
+| 8 | MiReveal #6.9 | `0xF68f40230E39067Ee7c98Fe9A8641fC124c5BE60` |
+| 9 | MiReveal #7.7 | `0xFc79B1BcCa172FF5a8F74205C82F5CBB0125Dd10` |
+| 10 | MiReveal #8.8 | `0xa3d3EF45712631A6Fb50c677762b8653f932cf71` |
+
+> **Technical details** — soulbound enforcement, minting mechanics, and deployment info: [FracturedMibera contract reference](../_codex/data/fractured-mibera.md)
+
+---
+
+<!-- @generated:backlinks-start -->
+<!-- @generated:backlinks-end -->

--- a/fractures/miladies.md
+++ b/fractures/miladies.md
@@ -1,0 +1,20 @@
+---
+phase: 2
+name: "Miladies"
+type: fracture
+symbol: MILADIES
+contract: "0x8D4972bd5D2df474e71da6676a365fB549853991"
+---
+
+# Miladies
+
+> **Phase 2** · MILADIES · [All Fractures →](README.md)
+
+Horizontally flipped Milady Maker art with toilet graffiti scrawled on top. Before Mibera can exist, it must acknowledge where it came from — and deface it.
+
+The Miladies phase is a bridge between lineages. Milady had to die so that Milady may live. This phase crystallizes that transition: familiar art, mirrored and vandalized, marking the moment the Mibera identity begins to diverge from its ancestor.
+
+---
+
+<!-- @generated:backlinks-start -->
+<!-- @generated:backlinks-end -->

--- a/fractures/miparcels.md
+++ b/fractures/miparcels.md
@@ -1,0 +1,20 @@
+---
+phase: 1
+name: "MiParcels"
+type: fracture
+symbol: MIPARCEL
+contract: "0x6956dae88C00372B1A0b2dfBfE5Eed19F85b0D4B"
+---
+
+# MiParcels
+
+> **Phase 1** · MIPARCEL · [All Fractures →](README.md)
+
+Sealed envelopes covered in various labels, stickers, and handwritten scrawl from the Mibera lore. The first thing holders see is a package — not a being, not even a promise of one. Just anticipation in physical form.
+
+MiParcels is pure mystery. No hint of what's inside, no preview of the Mibera to come. The parcel itself is the art — a sealed container that asks you to trust the process.
+
+---
+
+<!-- @generated:backlinks-start -->
+<!-- @generated:backlinks-end -->

--- a/fractures/mireveal-1.1.md
+++ b/fractures/mireveal-1.1.md
@@ -1,0 +1,25 @@
+---
+phase: 3
+name: "MiReveal #1.1"
+type: fracture
+symbol: MIREVEAL1.1
+contract: "0x77ec6B83495974a5B2C5BEf943b0f2e5aCd8Fc26"
+---
+
+# MiReveal #1.1
+
+> **Phase 3** · MIREVEAL1.1 · [All Fractures →](README.md)
+
+The first thing Miladies see upon opening their package is a smattering of colors and only the promise of a Mibera. This stage is meant to evoke some amount of uncertainty, but also give a substantial enough hint about what sort of scenery is surrounding Mibera.
+
+In fact, Mibera may be found behind a rare foreground at this phase. GG to those who have been seeking some certainty.
+
+### What's Revealed
+
+- Background colors and scenery hints
+- Rare foregrounds visible for some Miberas
+
+---
+
+<!-- @generated:backlinks-start -->
+<!-- @generated:backlinks-end -->

--- a/fractures/mireveal-2.2.md
+++ b/fractures/mireveal-2.2.md
@@ -1,0 +1,24 @@
+---
+phase: 4
+name: "MiReveal #2.2"
+type: fracture
+symbol: MIREVEAL2.2
+contract: "0xc557Bf6C7d21BA98A40dDfE2BEAbA682C49D17A9"
+---
+
+# MiReveal #2.2
+
+> **Phase 4** · MIREVEAL2.2 · [All Fractures →](README.md)
+
+Miladies' first taste of certainty is unveiled in this stage. The scene is clear at last, and the molecule is now prominently placed in the upper left corner. The silhouette of the final Mibera is also shown in this phase, giving Miladies a hazy glimpse into the future.
+
+### What's Revealed
+
+- Full background scene
+- [Molecule](../traits/overlays/molecules.md) placed in the upper left corner
+- Mibera silhouette — a shadow of the final form
+
+---
+
+<!-- @generated:backlinks-start -->
+<!-- @generated:backlinks-end -->

--- a/fractures/mireveal-3.3.md
+++ b/fractures/mireveal-3.3.md
@@ -1,0 +1,24 @@
+---
+phase: 5
+name: "MiReveal #3.3"
+type: fracture
+symbol: MIREVEAL3.3
+contract: "0xbcb082bB41E892f29d9c600eaadEA698d5f712Ef"
+---
+
+# MiReveal #3.3
+
+> **Phase 5** · MIREVEAL3.3 · [All Fractures →](README.md)
+
+Mibera takes on a more coherent form in this phase and begins to reveal their astrology. Their eyes are closed, face expressionless — the hope here is for Miladies to wonder: "When will Mibera wake up?"
+
+### What's Revealed
+
+- Mibera's form becomes coherent
+- [Astrology](../traits/overlays/astrology/README.md) begins to show — sun sign visible
+- Eyes closed, face expressionless — still sleeping
+
+---
+
+<!-- @generated:backlinks-start -->
+<!-- @generated:backlinks-end -->

--- a/fractures/mireveal-4.20.md
+++ b/fractures/mireveal-4.20.md
@@ -1,0 +1,24 @@
+---
+phase: 6
+name: "MiReveal #4.20"
+type: fracture
+symbol: MIREVEAL4.20
+contract: "0x2030f226Bf9a0c88687e83AcCdcEfb7Dae260094"
+---
+
+# MiReveal #4.20
+
+> **Phase 6** · MIREVEAL4.20 · [All Fractures →](README.md)
+
+Mibera continues to sleep as the moon shows itself, though if they have a hat then it is gently placed on their head. Many Miberas will not have said hat. The amount of color this adds to the overall collection upon this phase warrants the hat being the only real visual addition to Mibera.
+
+### What's Revealed
+
+- Moon appears in the scene
+- [Hat](../traits/accessories/hats/README.md) placed (if applicable — many Miberas go hatless)
+- Mibera still sleeping
+
+---
+
+<!-- @generated:backlinks-start -->
+<!-- @generated:backlinks-end -->

--- a/fractures/mireveal-5.5.md
+++ b/fractures/mireveal-5.5.md
@@ -1,0 +1,25 @@
+---
+phase: 7
+name: "MiReveal #5.5"
+type: fracture
+symbol: MIREVEAL5.5
+contract: "0xcc426F9375c5edcef5CA6bDb0449c07113348cF7"
+---
+
+# MiReveal #5.5
+
+> **Phase 7** · MIREVEAL5.5 · [All Fractures →](README.md)
+
+With the rising sign now visible, Miladies should be aware that Mibera is awake at last — as if their now open eyes did not make that obvious already. As they start to take in the scene around them, their mouth takes its final shape and their face and ears are adorned accordingly. Mibera is starting to feel ready for the world, but is the world ready for Mibera?
+
+### What's Revealed
+
+- Mibera **wakes up** — eyes open
+- [Rising sign](../traits/overlays/astrology/README.md) becomes visible
+- [Mouth](../traits/character-traits/mouth/README.md) takes final shape
+- [Face accessories](../traits/accessories/face-accessories/README.md) and [earrings](../traits/accessories/earrings/README.md) appear
+
+---
+
+<!-- @generated:backlinks-start -->
+<!-- @generated:backlinks-end -->

--- a/fractures/mireveal-6.9.md
+++ b/fractures/mireveal-6.9.md
@@ -1,0 +1,24 @@
+---
+phase: 8
+name: "MiReveal #6.9"
+type: fracture
+symbol: MIREVEAL6.9
+contract: "0xF68f40230E39067Ee7c98Fe9A8641fC124c5BE60"
+---
+
+# MiReveal #6.9
+
+> **Phase 8** · MIREVEAL6.9 · [All Fractures →](README.md)
+
+Mibera has become rather comfortable, as their head has now taken its final form. The overlay will remain the same for most — but those with an ancient emblem will get to see it in the lower right corner. This will be the only point at which anyone gets to see the naked ancient emblem.
+
+### What's Revealed
+
+- Head takes **final form** — [hair](../traits/character-traits/hair/README.md), complete silhouette
+- Ancient emblem visible in lower right corner (if applicable)
+- The only phase where the ancient emblem appears unadorned
+
+---
+
+<!-- @generated:backlinks-start -->
+<!-- @generated:backlinks-end -->

--- a/fractures/mireveal-7.7.md
+++ b/fractures/mireveal-7.7.md
@@ -1,0 +1,23 @@
+---
+phase: 9
+name: "MiReveal #7.7"
+type: fracture
+symbol: MIREVEAL7.7
+contract: "0xFc79B1BcCa172FF5a8F74205C82F5CBB0125Dd10"
+---
+
+# MiReveal #7.7
+
+> **Phase 9** · MIREVEAL7.7 · [All Fractures →](README.md)
+
+Many Miberas will decide to get a tattoo before the final reveal, showing Miladies more of their unique personhood. This phase is decidedly calm before the next. The contrast it creates should be palpable.
+
+### What's Revealed
+
+- [Tattoos](../traits/character-traits/tattoos/README.md) applied (for those who have them)
+- A deliberately quiet phase — the calm before the storm
+
+---
+
+<!-- @generated:backlinks-start -->
+<!-- @generated:backlinks-end -->

--- a/fractures/mireveal-8.8.md
+++ b/fractures/mireveal-8.8.md
@@ -1,0 +1,18 @@
+---
+phase: 10
+name: "MiReveal #8.8"
+type: fracture
+symbol: MIREVEAL8.8
+contract: "0xa3d3EF45712631A6Fb50c677762b8653f932cf71"
+---
+
+# MiReveal #8.8
+
+> **Phase 10** · MIREVEAL8.8 · [All Fractures →](README.md)
+
+The final reveal. Everything comes together — clothing, items, glasses, masks, and any remaining traits land in their final positions. This is the Mibera collection as it exists today. The journey from sealed envelope to fully-realized time-travelling Rebased Retard Bera is complete.
+
+---
+
+<!-- @generated:backlinks-start -->
+<!-- @generated:backlinks-end -->

--- a/glossary.md
+++ b/glossary.md
@@ -38,6 +38,16 @@ The mapping of 78 tarot cards to 78 psychoactive substances. Each Mibera carries
 
 ---
 
+## F
+
+### Fracture
+One of 10 soulbound ERC-721 collections representing the reveal phases of the Mibera collection. Each Fracture marks a step in the progression from sealed envelope (MiParcels) to fully-realized Mibera (MiReveal #8.8). Holders mint their corresponding token ID as permanent on-chain proof of participation in each reveal wave. See: [Fractures](fractures/README.md)
+
+### FracturedMibera
+The smart contract system powering the 10 Fracture collections. Enforces soulbound (non-transferable) tokens with 1:1 token ID mapping to the main Mibera collection. See: [Technical Reference](_codex/data/fractured-mibera.md)
+
+---
+
 ## H
 
 ### High Council of 101 Bears

--- a/grimoires/loa/archive/cycle-012/prd.md
+++ b/grimoires/loa/archive/cycle-012/prd.md
@@ -1,0 +1,95 @@
+# PRD: Schema Meta Blocks — Field-Level Confidence
+
+**Cycle**: 012
+**Date**: 2026-02-18
+**Issue**: #15 P2 item — schema meta blocks with confidence levels
+
+---
+
+## 1. Problem Statement
+
+The codex has 8 JSON Schema files defining entity structures, but they contain no provenance or confidence metadata. A consumer (agent, app, researcher) cannot programmatically determine whether a field's value comes from on-chain contract metadata (canonical), was derived from pattern analysis, or was community-contributed.
+
+> Sources: Issue #15 P2 item, NOTES.md decision log
+
+## 2. Goals
+
+1. Add machine-readable confidence annotations to all 8 schema files
+2. Use JSON Schema's `x-` extension mechanism (non-breaking)
+3. Enable consumers to filter or weight data by confidence level
+
+## 3. Success Criteria
+
+- All 8 schema files have `x-codex-meta` blocks
+- Every field in every schema has a confidence annotation
+- Annotations use a controlled vocabulary: `canonical`, `derived`, `community`
+- Source authority is documented per field
+- Existing schema validation is unaffected (no breaking changes)
+
+## 4. Scope
+
+### In Scope
+
+- Add `x-codex-meta` extension to all 8 `_codex/schema/*.schema.json` files
+- Document confidence vocabulary in a schema README or inline
+- Validate that schemas still parse correctly after modification
+
+### Out of Scope
+
+- Modifying actual entity data files
+- Adding per-record confidence (this is schema-level, not instance-level)
+- Changing manifest.json (already has aggregate completeness)
+
+## 5. Confidence Vocabulary
+
+| Level | Meaning | Example |
+|-------|---------|---------|
+| `canonical` | From on-chain metadata or contract state | Mibera archetype, element, swag_score |
+| `derived` | Computed from canonical data via deterministic rules | Swag rank (derived from score thresholds) |
+| `community` | Community-contributed, editorial, or artist-sourced | Grail descriptions, drug origins, ancestor locations |
+
+## 6. Format
+
+Each schema property gains an `x-codex-confidence` annotation:
+
+```json
+{
+  "archetype": {
+    "type": "string",
+    "enum": ["Freetekno", "Milady", "Acidhouse", "Chicago/Detroit"],
+    "description": "One of 4 archetypes",
+    "x-codex-confidence": "canonical",
+    "x-codex-source": "contract-metadata"
+  }
+}
+```
+
+Each schema file also gets a top-level `x-codex-meta` block:
+
+```json
+{
+  "x-codex-meta": {
+    "entity_type": "mibera",
+    "confidence_summary": "All fields canonical except swag_rank (derived)",
+    "last_verified": "2026-02-18"
+  }
+}
+```
+
+## 7. Entity Confidence Assessment
+
+| Schema | Fields | Confidence Profile |
+|--------|--------|--------------------|
+| `mibera.schema.json` | 26 | Nearly all canonical (contract metadata). `swag_rank` is derived. |
+| `drug.schema.json` | 9 | Mixed: `name`, `archetype`, `ancestor` canonical; `molecule`, `era`, `origin` community-sourced |
+| `ancestor.schema.json` | 4 | All community (historical research) |
+| `tarot-card.schema.json` | TBD | Check source |
+| `trait-full.schema.json` | TBD | Check source |
+| `trait-minimal.schema.json` | TBD | Check source |
+| `special-collection.schema.json` | TBD | Check source |
+| `grail.schema.json` | 7 | `id`, `name`, `type` canonical; `category`, `description` community; `commissioned_for`, `status` mixed |
+
+## 8. Risks
+
+- **Low**: JSON Schema parsers ignore `x-` extensions by default — no breakage risk
+- **Low**: Confidence assessment is subjective for some fields — document rationale

--- a/grimoires/loa/archive/cycle-012/sdd.md
+++ b/grimoires/loa/archive/cycle-012/sdd.md
@@ -1,0 +1,163 @@
+# SDD: Schema Meta Blocks — Field-Level Confidence
+
+**Cycle**: 012
+**Date**: 2026-02-18
+**PRD**: `grimoires/loa/prd.md`
+
+---
+
+## 1. Approach
+
+Use JSON Schema's `x-` extension convention to add two types of annotations:
+
+1. **Per-field**: `x-codex-confidence` and `x-codex-source` on each property
+2. **Per-schema**: `x-codex-meta` top-level block with summary and verification date
+
+This is a pure additive change — JSON Schema validators ignore unknown `x-` prefixed keys.
+
+## 2. Confidence Vocabulary
+
+| Value | Definition |
+|-------|-----------|
+| `canonical` | From on-chain contract state, generative algorithm, or official project metadata |
+| `derived` | Deterministically computed from canonical data (e.g., rank from score) |
+| `community` | Editorial content, historical research, artist descriptions, or user contributions |
+
+## 3. Source Vocabulary
+
+| Value | Definition |
+|-------|-----------|
+| `contract-metadata` | ERC-721 token metadata / generative mint output |
+| `project-lore` | Official project lore definitions (archetypes, ancestors, elements) |
+| `project-asset` | Official image/media assets |
+| `editorial` | Codex editorial content (dates added, descriptions) |
+| `research` | Historical, chemical, or cultural research |
+| `artist` | Artist-provided descriptions or attributions |
+| `classification` | Codex-defined categorization system |
+
+## 4. Field-Level Confidence Map
+
+### mibera.schema.json (26 properties)
+
+| Field | Confidence | Source |
+|-------|-----------|--------|
+| id | canonical | contract-metadata |
+| type | canonical | contract-metadata |
+| archetype | canonical | contract-metadata |
+| ancestor | canonical | contract-metadata |
+| time_period | canonical | contract-metadata |
+| birthday | canonical | contract-metadata |
+| birth_coordinates | canonical | contract-metadata |
+| sun_sign | canonical | contract-metadata |
+| moon_sign | canonical | contract-metadata |
+| ascending_sign | canonical | contract-metadata |
+| element | canonical | contract-metadata |
+| swag_rank | derived | contract-metadata |
+| swag_score | canonical | contract-metadata |
+| background | canonical | contract-metadata |
+| body | canonical | contract-metadata |
+| hair | canonical | contract-metadata |
+| eyes | canonical | contract-metadata |
+| eyebrows | canonical | contract-metadata |
+| mouth | canonical | contract-metadata |
+| shirt | canonical | contract-metadata |
+| hat | canonical | contract-metadata |
+| glasses | canonical | contract-metadata |
+| mask | canonical | contract-metadata |
+| earrings | canonical | contract-metadata |
+| face_accessory | canonical | contract-metadata |
+| tattoo | canonical | contract-metadata |
+| item | canonical | contract-metadata |
+| drug | canonical | contract-metadata |
+
+### drug.schema.json (9 properties)
+
+| Field | Confidence | Source |
+|-------|-----------|--------|
+| name | canonical | project-lore |
+| molecule | community | research |
+| era | canonical | project-lore |
+| origin | community | research |
+| archetype | canonical | project-lore |
+| ancestor | canonical | project-lore |
+| swag_score | canonical | project-lore |
+| image | canonical | project-asset |
+| date_added | community | editorial |
+
+### ancestor.schema.json (4 properties)
+
+| Field | Confidence | Source |
+|-------|-----------|--------|
+| name | canonical | project-lore |
+| period_ancient | community | research |
+| period_modern | community | research |
+| locations | community | research |
+
+### tarot-card.schema.json (7 properties)
+
+| Field | Confidence | Source |
+|-------|-----------|--------|
+| name | canonical | project-lore |
+| suit | canonical | project-lore |
+| element | canonical | project-lore |
+| meaning | community | research |
+| drug | canonical | project-lore |
+| drug_type | canonical | project-lore |
+| molecule | community | research |
+
+### trait-full.schema.json (5 properties)
+
+| Field | Confidence | Source |
+|-------|-----------|--------|
+| name | canonical | contract-metadata |
+| image | canonical | project-asset |
+| archetype | canonical | contract-metadata |
+| swag_score | canonical | contract-metadata |
+| date_added | community | editorial |
+
+### trait-minimal.schema.json (3 properties)
+
+| Field | Confidence | Source |
+|-------|-----------|--------|
+| name | canonical | contract-metadata |
+| image | canonical | project-asset |
+| date_added | community | editorial |
+
+### special-collection.schema.json (2 properties)
+
+| Field | Confidence | Source |
+|-------|-----------|--------|
+| name | canonical | project-lore |
+| type | community | classification |
+
+### grail.schema.json (7 properties)
+
+| Field | Confidence | Source |
+|-------|-----------|--------|
+| id | canonical | contract-metadata |
+| name | canonical | artist |
+| type | canonical | classification |
+| category | community | classification |
+| description | community | artist |
+| commissioned_for | community | artist |
+| status | canonical | contract-metadata |
+
+## 5. Schema-Level Meta Block Format
+
+```json
+{
+  "x-codex-meta": {
+    "entity_type": "mibera",
+    "confidence_profile": "25/26 canonical, 1 derived (swag_rank)",
+    "primary_source": "contract-metadata",
+    "last_verified": "2026-02-18"
+  }
+}
+```
+
+## 6. Validation
+
+- All 8 files must remain valid JSON after modification
+- No existing keys may be changed or removed
+- `x-codex-confidence` must be one of: `canonical`, `derived`, `community`
+- `x-codex-source` must be one of the 7 source vocabulary values

--- a/grimoires/loa/archive/cycle-012/sprint.md
+++ b/grimoires/loa/archive/cycle-012/sprint.md
@@ -1,0 +1,50 @@
+# Sprint Plan: Schema Meta Blocks
+
+**Cycle**: 012
+**PRD**: `grimoires/loa/prd.md`
+**SDD**: `grimoires/loa/sdd.md`
+
+---
+
+## Overview
+
+Single sprint. Add `x-codex-confidence`, `x-codex-source`, and `x-codex-meta` to 8 schema files.
+
+---
+
+## Sprint 1: Schema Meta Annotations
+
+**Goal**: Add field-level confidence annotations and schema-level meta blocks to all 8 JSON Schema files.
+
+### Task 1.1: Annotate all 8 schema files
+
+**Description**: For each property in each schema file, add `x-codex-confidence` and `x-codex-source` inline. Add `x-codex-meta` top-level block. Values per SDD Section 4.
+
+**Files**:
+1. `_codex/schema/mibera.schema.json` — 26 properties
+2. `_codex/schema/drug.schema.json` — 9 properties
+3. `_codex/schema/ancestor.schema.json` — 4 properties
+4. `_codex/schema/tarot-card.schema.json` — 7 properties
+5. `_codex/schema/trait-full.schema.json` — 5 properties
+6. `_codex/schema/trait-minimal.schema.json` — 3 properties
+7. `_codex/schema/special-collection.schema.json` — 2 properties
+8. `_codex/schema/grail.schema.json` — 7 properties
+
+**Acceptance criteria**:
+- [x] All 8 schema files have `x-codex-meta` top-level block
+- [x] Every property in every schema has `x-codex-confidence` and `x-codex-source`
+- [x] Confidence values are only `canonical`, `derived`, or `community`
+- [x] Source values are from the 7-value vocabulary in SDD Section 3
+- [x] All files are valid JSON
+
+### Task 1.2: Validate
+
+**Description**: Verify all annotations are correct and schemas remain valid.
+
+**Acceptance criteria**:
+- [x] All 8 files parse as valid JSON
+- [x] No existing schema properties were modified or removed
+- [x] Confidence/source values match SDD Section 4 mapping
+- [x] `x-codex-meta.last_verified` is `2026-02-18` on all files
+
+**Dependencies**: Task 1.1

--- a/grimoires/loa/ledger.json
+++ b/grimoires/loa/ledger.json
@@ -272,12 +272,12 @@
     {
       "id": "cycle-012",
       "label": "Schema Meta Blocks — Field-Level Confidence",
-      "status": "active",
+      "status": "archived",
       "created": "2026-02-18",
-      "archived": null,
-      "prd": "grimoires/loa/prd.md",
-      "sdd": "grimoires/loa/sdd.md",
-      "sprint_plan": "grimoires/loa/sprint.md",
+      "archived": "2026-02-18",
+      "prd": "grimoires/loa/archive/cycle-012/prd.md",
+      "sdd": "grimoires/loa/archive/cycle-012/sdd.md",
+      "sprint_plan": "grimoires/loa/archive/cycle-012/sprint.md",
       "sprints": [
         {
           "id": "sprint-1",
@@ -288,10 +288,30 @@
         }
       ],
       "sprint_count": 1
+    },
+    {
+      "id": "cycle-013",
+      "label": "Fractures — Reveal Phase Documentation",
+      "status": "active",
+      "created": "2026-02-18",
+      "archived": null,
+      "prd": "grimoires/loa/prd.md",
+      "sdd": null,
+      "sprint_plan": "grimoires/loa/sprint.md",
+      "sprints": [
+        {
+          "id": "sprint-1",
+          "global_id": 20,
+          "label": "Fractures Content & Integration",
+          "status": "completed",
+          "tasks": 4
+        }
+      ],
+      "sprint_count": 1
     }
   ],
-  "active_cycle": "cycle-012",
+  "active_cycle": "cycle-013",
   "active_bugfix": null,
-  "global_sprint_counter": 19,
+  "global_sprint_counter": 20,
   "bugfix_cycles": []
 }

--- a/grimoires/loa/prd.md
+++ b/grimoires/loa/prd.md
@@ -1,95 +1,66 @@
-# PRD: Schema Meta Blocks — Field-Level Confidence
+# PRD: Fractures — Reveal Phase Documentation
 
-**Cycle**: 012
+**Cycle**: 013
 **Date**: 2026-02-18
-**Issue**: #15 P2 item — schema meta blocks with confidence levels
 
 ---
 
 ## 1. Problem Statement
 
-The codex has 8 JSON Schema files defining entity structures, but they contain no provenance or confidence metadata. A consumer (agent, app, researcher) cannot programmatically determine whether a field's value comes from on-chain contract metadata (canonical), was derived from pattern analysis, or was community-contributed.
+FracturedMibera represents the 10 reveal phases of the Mibera collection — soulbound on-chain markers of each holder's participation in the reveal timeline. Currently, the only documentation lives in `_codex/data/fractured-mibera.md` as a technical contract reference. There is no narrative documentation of what each reveal phase actually unveiled, the progression from sealed envelopes to final form, or the cultural significance of the naming convention.
 
-> Sources: Issue #15 P2 item, NOTES.md decision log
+Fractures are as central to the collection's identity as Grails and Birthdays. They deserve a first-class section in "V. The Collection."
 
 ## 2. Goals
 
-1. Add machine-readable confidence annotations to all 8 schema files
-2. Use JSON Schema's `x-` extension mechanism (non-breaking)
-3. Enable consumers to filter or weight data by confidence level
+1. Create a `/fractures/` directory as a peer to `/grails/` and `/birthdays/`
+2. Document each of the 10 reveal phases with narrative descriptions
+3. Preserve the reveal timeline as a coherent story of Mibera coming into being
+4. Link to (not duplicate) the technical contract mechanics in `_codex/data/`
+5. Update glossary, README, and SUMMARY to integrate the new section
 
-## 3. Success Criteria
+## 3. The 10 Fractures
 
-- All 8 schema files have `x-codex-meta` blocks
-- Every field in every schema has a confidence annotation
-- Annotations use a controlled vocabulary: `canonical`, `derived`, `community`
-- Source authority is documented per field
-- Existing schema validation is unaffected (no breaking changes)
+| # | Name | Symbol | What It Reveals |
+|---|------|--------|-----------------|
+| 1 | MiParcels | MIPARCEL | Sealed envelopes with labels, stickers, handwritten lore scrawl |
+| 2 | Miladies | MILADIES | Horizontally flipped Milady Maker art with toilet graffiti |
+| 3 | MiReveal #1.1 | MIREVEAL1.1 | Colors and scenery hints; rare foregrounds visible |
+| 4 | MiReveal #2.2 | MIREVEAL2.2 | Scene clears, molecule placed, silhouette shown |
+| 5 | MiReveal #3.3 | MIREVEAL3.3 | Coherent form, astrology revealed, eyes closed |
+| 6 | MiReveal #4.20 | MIREVEAL4.20 | Moon appears, hat placed (if applicable) |
+| 7 | MiReveal #5.5 | MIREVEAL5.5 | Mibera awake, rising sign visible, face finalized |
+| 8 | MiReveal #6.9 | MIREVEAL6.9 | Head takes final form, ancient emblem visible |
+| 9 | MiReveal #7.7 | MIREVEAL7.7 | Tattoos added, calm before the final reveal |
+| 10 | MiReveal #8.8 | MIREVEAL8.8 | Final reveal — the current Mibera collection |
 
-## 4. Scope
+### Naming Convention
+
+The decimal numbering (1.1, 2.2, 3.3, 4.20, 5.5, 6.9, 7.7, 8.8) is playful and intentional. 4.20 and 6.9 are deliberate cultural references.
+
+### MiParcels & Miladies
+
+These first two phases differ from the numbered MiReveals — they're not progressive unveilings of the Mibera form but rather conceptual predecessors. MiParcels is pure anticipation (a sealed package). Miladies is a nod to the Milady lineage before Mibera emerges as its own identity.
+
+## 4. Success Criteria
+
+- `/fractures/README.md` with overview, timeline, and contract reference table
+- 10 individual phase files with narrative descriptions
+- `glossary.md` updated with Fracture/FracturedMibera terms
+- `README.md` Section V updated to include Fractures
+- `SUMMARY.md` updated with Fractures entries
+- All files link to `_codex/data/fractured-mibera.md` for technical details
+
+## 5. Scope
 
 ### In Scope
-
-- Add `x-codex-meta` extension to all 8 `_codex/schema/*.schema.json` files
-- Document confidence vocabulary in a schema README or inline
-- Validate that schemas still parse correctly after modification
+- Narrative reveal timeline documentation
+- Per-phase markdown files
+- Navigation integration (README, SUMMARY, glossary)
+- Cross-links to technical reference
 
 ### Out of Scope
-
-- Modifying actual entity data files
-- Adding per-record confidence (this is schema-level, not instance-level)
-- Changing manifest.json (already has aggregate completeness)
-
-## 5. Confidence Vocabulary
-
-| Level | Meaning | Example |
-|-------|---------|---------|
-| `canonical` | From on-chain metadata or contract state | Mibera archetype, element, swag_score |
-| `derived` | Computed from canonical data via deterministic rules | Swag rank (derived from score thresholds) |
-| `community` | Community-contributed, editorial, or artist-sourced | Grail descriptions, drug origins, ancestor locations |
-
-## 6. Format
-
-Each schema property gains an `x-codex-confidence` annotation:
-
-```json
-{
-  "archetype": {
-    "type": "string",
-    "enum": ["Freetekno", "Milady", "Acidhouse", "Chicago/Detroit"],
-    "description": "One of 4 archetypes",
-    "x-codex-confidence": "canonical",
-    "x-codex-source": "contract-metadata"
-  }
-}
-```
-
-Each schema file also gets a top-level `x-codex-meta` block:
-
-```json
-{
-  "x-codex-meta": {
-    "entity_type": "mibera",
-    "confidence_summary": "All fields canonical except swag_rank (derived)",
-    "last_verified": "2026-02-18"
-  }
-}
-```
-
-## 7. Entity Confidence Assessment
-
-| Schema | Fields | Confidence Profile |
-|--------|--------|--------------------|
-| `mibera.schema.json` | 26 | Nearly all canonical (contract metadata). `swag_rank` is derived. |
-| `drug.schema.json` | 9 | Mixed: `name`, `archetype`, `ancestor` canonical; `molecule`, `era`, `origin` community-sourced |
-| `ancestor.schema.json` | 4 | All community (historical research) |
-| `tarot-card.schema.json` | TBD | Check source |
-| `trait-full.schema.json` | TBD | Check source |
-| `trait-minimal.schema.json` | TBD | Check source |
-| `special-collection.schema.json` | TBD | Check source |
-| `grail.schema.json` | 7 | `id`, `name`, `type` canonical; `category`, `description` community; `commissioned_for`, `status` mixed |
-
-## 8. Risks
-
-- **Low**: JSON Schema parsers ignore `x-` extensions by default — no breakage risk
-- **Low**: Confidence assessment is subjective for some fields — document rationale
+- Contract mechanics (already documented in `_codex/data/`)
+- Mint stats per Fracture (data not available)
+- Per-phase visual identity/art samples
+- mireveals/ CSV data (gitignored, in-progress)

--- a/grimoires/loa/sprint.md
+++ b/grimoires/loa/sprint.md
@@ -1,50 +1,48 @@
-# Sprint Plan: Schema Meta Blocks
+# Sprint Plan: Fractures — Reveal Phase Documentation
 
-**Cycle**: 012
-**PRD**: `grimoires/loa/prd.md`
-**SDD**: `grimoires/loa/sdd.md`
-
----
-
-## Overview
-
-Single sprint. Add `x-codex-confidence`, `x-codex-source`, and `x-codex-meta` to 8 schema files.
+**Cycle**: 013
+**Sprint**: 1 (Global: 20)
+**Label**: Fractures Content & Integration
 
 ---
 
-## Sprint 1: Schema Meta Annotations
+## Tasks
 
-**Goal**: Add field-level confidence annotations and schema-level meta blocks to all 8 JSON Schema files.
+### Task 1: Create fractures/README.md
+**Priority**: P0
+**Acceptance Criteria**:
+- Overview of what Fractures are (soulbound reveal phase markers)
+- Timeline table with all 10 phases, names, symbols, and contract addresses
+- Naming convention explanation
+- Link to `_codex/data/fractured-mibera.md` for technical/contract details
+- Links to each individual phase file
 
-### Task 1.1: Annotate all 8 schema files
+### Task 2: Create individual phase files (10 files)
+**Priority**: P0
+**Acceptance Criteria**:
+- `miparcels.md` — sealed envelopes, labels, stickers, lore scrawl
+- `miladies.md` — flipped Milady Maker art, toilet graffiti
+- `mireveal-1.1.md` — colors, scenery hints, rare foregrounds
+- `mireveal-2.2.md` — scene clears, molecule, silhouette
+- `mireveal-3.3.md` — coherent form, astrology, eyes closed
+- `mireveal-4.20.md` — moon, hat placement
+- `mireveal-5.5.md` — awake, rising sign, face finalized
+- `mireveal-6.9.md` — head final form, ancient emblem
+- `mireveal-7.7.md` — tattoos, calm before storm
+- `mireveal-8.8.md` — final reveal, current collection
+- Each file has: YAML frontmatter, phase number, contract address, symbol, narrative description
+- Backlink markers included
 
-**Description**: For each property in each schema file, add `x-codex-confidence` and `x-codex-source` inline. Add `x-codex-meta` top-level block. Values per SDD Section 4.
+### Task 3: Update navigation (README, SUMMARY, glossary)
+**Priority**: P0
+**Acceptance Criteria**:
+- `README.md` Section V includes Fractures link
+- `SUMMARY.md` includes Fractures section with all phase files
+- `glossary.md` has entries for Fracture/FracturedMibera
 
-**Files**:
-1. `_codex/schema/mibera.schema.json` — 26 properties
-2. `_codex/schema/drug.schema.json` — 9 properties
-3. `_codex/schema/ancestor.schema.json` — 4 properties
-4. `_codex/schema/tarot-card.schema.json` — 7 properties
-5. `_codex/schema/trait-full.schema.json` — 5 properties
-6. `_codex/schema/trait-minimal.schema.json` — 3 properties
-7. `_codex/schema/special-collection.schema.json` — 2 properties
-8. `_codex/schema/grail.schema.json` — 7 properties
-
-**Acceptance criteria**:
-- [x] All 8 schema files have `x-codex-meta` top-level block
-- [x] Every property in every schema has `x-codex-confidence` and `x-codex-source`
-- [x] Confidence values are only `canonical`, `derived`, or `community`
-- [x] Source values are from the 7-value vocabulary in SDD Section 3
-- [x] All files are valid JSON
-
-### Task 1.2: Validate
-
-**Description**: Verify all annotations are correct and schemas remain valid.
-
-**Acceptance criteria**:
-- [x] All 8 files parse as valid JSON
-- [x] No existing schema properties were modified or removed
-- [x] Confidence/source values match SDD Section 4 mapping
-- [x] `x-codex-meta.last_verified` is `2026-02-18` on all files
-
-**Dependencies**: Task 1.1
+### Task 4: Validate links and structure
+**Priority**: P1
+**Acceptance Criteria**:
+- All internal links resolve
+- Backlink markers present
+- File structure mirrors grails/birthdays pattern


### PR DESCRIPTION
## Summary
- Adds top-level `/fractures/` directory documenting the 10 FracturedMibera reveal phases
- Each phase gets its own file with YAML frontmatter, narrative description, and trait cross-links
- MiParcels (sealed envelopes) → Miladies (flipped Milady art) → MiReveal #1.1 through #8.8 (progressive unveiling)
- Links to existing `_codex/data/fractured-mibera.md` for contract mechanics rather than duplicating
- Updates README (Section V), SUMMARY, and glossary with Fractures entries

## Test plan
- [ ] Verify `fractures/README.md` renders correctly on GitHub with timeline table and contract addresses
- [ ] Spot-check individual phase files (miparcels.md, mireveal-4.20.md, mireveal-8.8.md) for correct frontmatter and cross-links
- [ ] Confirm glossary entries appear in correct alphabetical order (F between D and H)
- [ ] Verify all cross-links to trait directories resolve (molecules, astrology, hats, tattoos, etc.)
- [ ] Check SUMMARY.md shows all 11 fractures entries nested correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)