### PR TITLE
Embed Irys-hosted images in all 42 canonical Grail entries

### DIFF
--- a/grails/air.md
+++ b/grails/air.md
@@ -8,6 +8,8 @@ description: "Cloud-like figure with sun filtering through"
 
 # Air
 
+![Air](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/air.PNG)
+
 > **Grail #2769** · Element · [Browse all Grails →](../browse/grails.md)
 
 Cloud-like figure meant to evoke air. Brightness to evoke the sun filtering through. Air + sun, providing life.

--- a/grails/aquarius.md
+++ b/grails/aquarius.md
@@ -8,6 +8,8 @@ description: "Hades as Aquarius with circulatory system and Uranus frequency"
 
 # Aquarius
 
+![Aquarius](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/aquarius.png)
+
 > **Grail #6805** · Zodiac · [Browse all Grails →](../browse/grails.md)
 
 Hades as Aquarius. Circulatory system focus on body, Aquarius rules the circulatory system. Connection to Pluto on amphora. Glowing eyes in water to represent River Styx, same glowing eyes as in Jungle Lab background. 207.36 Hz Uranus ruling planet frequency flow of background. Alex Grey inspired background. Blue and purple, intellect and power.

--- a/grails/aries.md
+++ b/grails/aries.md
@@ -8,6 +8,8 @@ description: "Dumuzi the Shepherd as Aries with ram skull and Mars frequency"
 
 # Aries
 
+![Aries](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/aries.PNG)
+
 > **Grail #4803** · Zodiac · [Browse all Grails →](../browse/grails.md)
 
 Dumuzi the Shepherd as Aries. Ram skull. Eyes to evoke passion. Dead flowers evoke dry season, story of Inanna and Dumuzi. 144.72 Hz frequency of Mars subtle in background.

--- a/grails/black-hole.md
+++ b/grails/black-hole.md
@@ -8,6 +8,8 @@ description: "Mibera drawn within a black hole, evoking uncertainty"
 
 # Black Hole
 
+![Black Hole](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/black hole.PNG)
+
 > **Grail #876** · Concept · [Browse all Grails →](../browse/grails.md)
 
 Mibera drawn within a black hole. Unreadable void presence within the unknown meant to evoke uncertainty.

--- a/grails/buddhist.md
+++ b/grails/buddhist.md
@@ -8,6 +8,8 @@ description: "Medicine Buddha thangka with amrita and blue lotus blotter"
 
 # Buddhist
 
+![Buddhist](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/buddhist.PNG)
+
 > **Grail #9503** · Ancestor · [Browse all Grails →](../browse/grails.md)
 
 Medicine Buddha thangka inspired art. Holding amrita. Blue lotus blotter art on clothes.

--- a/grails/cancer.md
+++ b/grails/cancer.md
@@ -8,6 +8,8 @@ description: "Cancer crab hues with Bicycle Day blotter art, moon side"
 
 # Cancer
 
+![Cancer](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/cancer.PNG)
+
 > **Grail #8620** · Zodiac · [Browse all Grails →](../browse/grails.md)
 
 Colors, crab associated with Cancer. Delphinium in foreground. Albert Hoffman Bicycle Day blotter art in background, moon side.

--- a/grails/capricorn.md
+++ b/grails/capricorn.md
@@ -8,6 +8,8 @@ description: "Aegipan and Pan as Capricorn with Saturn frequency and 7 pipes"
 
 # Capricorn
 
+![Capricorn](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/capricorn.png)
+
 > **Grail #8971** · Zodiac · [Browse all Grails →](../browse/grails.md)
 
 Aegipan + Pan as Capricorn. 147.85 Hz Saturn ruling planet frequency faint in background. 7 flute pipes = 7 classical planets. Green tones to put emphasis on earth sign despite water associations. Expression to evoke determination.

--- a/grails/chinese.md
+++ b/grails/chinese.md
@@ -8,6 +8,8 @@ description: "Chen Hongshou inspired with opium poppy and yin yang overlay"
 
 # Chinese
 
+![Chinese](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/chinese.PNG)
+
 > **Grail #392** · Ancestor · [Browse all Grails →](../browse/grails.md)
 
 Opium poppy in background. Yin yang reflected in overlay. Inspired by Preparing the Elixir Beneath a Pine by Chen Hongshou.

--- a/grails/earth.md
+++ b/grails/earth.md
@@ -8,6 +8,8 @@ description: "Green life tones with grounded hair and textured figure"
 
 # Earth
 
+![Earth](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/earth.PNG)
+
 > **Grail #3244** · Element · [Browse all Grails →](../browse/grails.md)
 
 Focus on green to signify life. "Hair" drawn as if attached to the ground, stable and solid like earth. Smoother lines flowing around the textured figure to evoke the movement that the earth facilitates. Presence of light in the chest to evoke connection to the sun, providing life.

--- a/grails/ethiopian.md
+++ b/grails/ethiopian.md
@@ -8,6 +8,8 @@ description: "Harari outfit with khat and scroll art spirals"
 
 # Ethiopian
 
+![Ethiopian](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/ethiopian.PNG)
+
 > **Grail #7702** · Ancestor · [Browse all Grails →](../browse/grails.md)
 
 Harari inspired outfit. Holding khat. Eyes and spirals from recurring scroll art elements.

--- a/grails/fire.md
+++ b/grails/fire.md
@@ -8,6 +8,8 @@ description: "Pyromantic hues with radiating heat and chest light evoking the su
 
 # Fire
 
+![Fire](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/fire.PNG)
+
 > **Grail #6458** · Element · [Browse all Grails →](../browse/grails.md)
 
 All hues associated with fire. Lines and movement radiating outwards like heat. Presence of light in the chest to evoke connection to the sun, providing life.

--- a/grails/future.md
+++ b/grails/future.md
@@ -8,6 +8,8 @@ description: "Robot statue with robotic ravens and Newgrange light patterns"
 
 # Future
 
+![Future](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/future.PNG)
+
 > **Grail #4734** · Concept · [Browse all Grails →](../browse/grails.md)
 
 Future robot version of the statue from the Past piece. Robot Huginn and Muninn as links to thought and memory. Light patterns to evoke rock art from Newgrange on the robot.

--- a/grails/gaia.md
+++ b/grails/gaia.md
@@ -8,6 +8,8 @@ description: "The earth"
 
 # Gaia
 
+![Gaia](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/gaia.png)
+
 > **Grail #3222** · Primordial · [Browse all Grails →](../browse/grails.md)
 
 > **Combined piece**: When Uranus is placed on top of Gaia, they form a single unified artwork.

--- a/grails/gemini.md
+++ b/grails/gemini.md
@@ -8,6 +8,8 @@ description: "Mibera and Milady as Gemini, inspired by Dali"
 
 # Gemini
 
+![Gemini](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/gemini.PNG)
+
 > **Grail #7218** · Zodiac · [Browse all Grails →](../browse/grails.md)
 
 Mibera and Milady gemini. Inspired by Dali's gemini gouache painting. 141.27 Hz frequency of Mercury in background.

--- a/grails/greek.md
+++ b/grails/greek.md
@@ -8,6 +8,8 @@ description: "Greek amphora aesthetics with Bacchus and Apollo"
 
 # Greek
 
+![Greek](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/greek.PNG)
+
 > **Grail #1630** · Ancestor · [Browse all Grails →](../browse/grails.md)
 
 Greek amphora inspired aesthetics. Bacchus and Apollo in background along with figures from assorted pieces.

--- a/grails/hindu.md
+++ b/grails/hindu.md
@@ -8,6 +8,8 @@ description: "Lord Shiva Grinding Bhang by Kailash Raj with crescent moon"
 
 # Hindu
 
+![Hindu](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/hindu.PNG)
+
 > **Grail #8277** · Ancestor · [Browse all Grails →](../browse/grails.md)
 
 Art inspired by Lord Shiva Grinding Bhang by Kailash Raj. Added crescent moon and river Ganga.

--- a/grails/japanese.md
+++ b/grails/japanese.md
@@ -8,6 +8,8 @@ description: "Ukiyo-e style with inro, torii gate, and mibera senjafuda"
 
 # Japanese
 
+![Japanese](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/japanese.PNG)
+
 > **Grail #4363** · Ancestor · [Browse all Grails →](../browse/grails.md)
 
 Holding an inro. Ukiyo-e inspired art style. Torii gate in background. Senjafuda that says "mibera" on top of the piece.

--- a/grails/jupiter.md
+++ b/grails/jupiter.md
@@ -8,6 +8,8 @@ description: "Zeus as Jupiter with 183.58 Hz frequency, gold divinity"
 
 # Jupiter
 
+![Jupiter](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/jupiter.png)
+
 > **Grail #3201** · Planet · [Browse all Grails →](../browse/grails.md)
 
 Zeus as Jupiter. Jupiter 183.58 Hz planetary frequency visual in background. Gold for divinity and power.

--- a/grails/leo.md
+++ b/grails/leo.md
@@ -8,6 +8,8 @@ description: "Lion skull with heart in hand — Leo rules the heart"
 
 # Leo
 
+![Leo](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/leo.PNG)
+
 > **Grail #9639** · Zodiac · [Browse all Grails →](../browse/grails.md)
 
 Lion skull. Jahangir coin earring. Heart in hand, Leo rules the heart. Sunflowers in foreground. Albert Hoffman Bicycle Day blotter art in background, sun side.

--- a/grails/libra.md
+++ b/grails/libra.md
@@ -8,6 +8,8 @@ description: "Themis as Libra with ouroboros sword and Venus frequency"
 
 # Libra
 
+![Libra](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/libra.png)
+
 > **Grail #895** · Zodiac · [Browse all Grails →](../browse/grails.md)
 
 Themis as Libra. Ouroboros on sword hilt. 221.23 Hz Venus ruling planet frequency on sword pommel. Plain background composition to bring figure into focal point, communicating truth and clarity. Colors evocative of Libra's season.

--- a/grails/mars.md
+++ b/grails/mars.md
@@ -8,6 +8,8 @@ description: "Tyr as Mars with 144.72 Hz frequency, reds and oranges"
 
 # Mars
 
+![Mars](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/mars.png)
+
 > **Grail #2566** · Planet · [Browse all Grails →](../browse/grails.md)
 
 Tyr as Mars. Mars 144.72 Hz planetary frequency visual in background. Reds and oranges to evoke the planet.

--- a/grails/mayan.md
+++ b/grails/mayan.md
@@ -8,6 +8,8 @@ description: "Mayan stela holding balche with Timewave Zero crack"
 
 # Mayan
 
+![Mayan](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/mayan.PNG)
+
 > **Grail #3970** · Ancestor · [Browse all Grails →](../browse/grails.md)
 
 Mayan stela as Mibera, holding a cup of balché. Timewave Zero graph as a crack in the stela. Main visuals pulled from Jonathan Solter's I've Been There.

--- a/grails/mercury.md
+++ b/grails/mercury.md
@@ -8,6 +8,8 @@ description: "Odin as Mercury with Huginn and Muninn, caduceus staff"
 
 # Mercury
 
+![Mercury](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/mercury.png)
+
 > **Grail #9112** · Planet · [Browse all Grails →](../browse/grails.md)
 
 Odin as Mercury. Mercury 141.27 Hz planetary frequency visual in background. Huginn and Muninn in foreground. Gungnir + caduceus staff. Hermes hat.

--- a/grails/mongolian.md
+++ b/grails/mongolian.md
@@ -8,6 +8,8 @@ description: "Simplified cave art with morin khuur and throat singing circles"
 
 # Mongolian
 
+![Mongolian](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/mongolian.PNG)
+
 > **Grail #507** · Ancestor · [Browse all Grails →](../browse/grails.md)
 
 Simplified Mongolian cave art. Holding a morin khuur. Circles moving outwards to represent sound, throat singing.

--- a/grails/moon.md
+++ b/grails/moon.md
@@ -8,6 +8,8 @@ description: "Speaker cone necklace with lunar phase crown, inspired by Selene"
 
 # Moon
 
+![Moon](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/moon.PNG)
+
 > **Grail #309** · Luminary · [Browse all Grails →](../browse/grails.md)
 
 Speaker cone necklace + crown representing every phase of the moon. General aesthetics inspired by Selene. 210.42 Hz planetary frequency displayed in the background.

--- a/grails/native-american.md
+++ b/grails/native-american.md
@@ -8,6 +8,8 @@ description: "Ledger art with Bear Ears Monument and elk tooth dress"
 
 # Native American
 
+![Native American](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/native american.png)
+
 > **Grail #3282** · Ancestor · [Browse all Grails →](../browse/grails.md)
 
 Native American ledger inspired art. Bear Ears National Monument in foreground. Bear Lodge in background. Wearing elk tooth dress. Wearing hat from A Cyborg Manifesto.

--- a/grails/neptune.md
+++ b/grails/neptune.md
@@ -8,6 +8,8 @@ description: "Poseidon as Neptune with trident and 211.44 Hz frequency"
 
 # Neptune
 
+![Neptune](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/neptune.png)
+
 > **Grail #2256** · Planet · [Browse all Grails →](../browse/grails.md)
 
 Poseidon as Neptune. Same Neptune trident as in Aphrodite/Pisces 1/1. Neptune 211.44 Hz planetary frequency visual in background.

--- a/grails/past.md
+++ b/grails/past.md
@@ -8,6 +8,8 @@ description: "Ancient statue with Huginn and Muninn, Newgrange rock art"
 
 # Past
 
+![Past](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/past.PNG)
+
 > **Grail #4221** · Concept · [Browse all Grails →](../browse/grails.md)
 
 Ancient statue in an unkempt environment to represent the passage of time. Huginn and Muninn as links to thought and memory. Rock art from Newgrange on the statue.

--- a/grails/pisces.md
+++ b/grails/pisces.md
@@ -8,6 +8,8 @@ description: "Aphrodite as Pisces with Neptune trident and Birth of Venus"
 
 # Pisces
 
+![Pisces](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/pisces.png)
+
 > **Grail #6409** · Zodiac · [Browse all Grails →](../browse/grails.md)
 
 Aphrodite as Pisces. Trident represents ruling planet Neptune. Fish as traditional Pisces reference. Birth of Venus background. Dreamy, content expression.

--- a/grails/pluto.md
+++ b/grails/pluto.md
@@ -8,6 +8,8 @@ description: "Hel as Pluto with key and sigil, evoking isolation"
 
 # Pluto
 
+![Pluto](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/pluto.png)
+
 > **Grail #1606** · Planet · [Browse all Grails →](../browse/grails.md)
 
 Hel as Pluto. Holding key + Pluto sigil. Blues, charcoals to evoke ash and deep space. Simple background + single light reflected in Hel's eye to evoke isolation.

--- a/grails/rastafarian.md
+++ b/grails/rastafarian.md
@@ -8,6 +8,8 @@ description: "Tom Wong tattoo with Great Sebastian record, Tokio Aoyama visuals"
 
 # Rastafarian
 
+![Rastafarian](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/rastafarian.png)
+
 > **Grail #1134** · Ancestor · [Browse all Grails →](../browse/grails.md)
 
 Tattoo of Tom Wong. Holding Tom the Great Sebastian record. Jamaica Broadcasting Corporation bus. Main visuals pulled from a Tokio Aoyama piece.

--- a/grails/sagittarius.md
+++ b/grails/sagittarius.md
@@ -8,6 +8,8 @@ description: "Inspired by Dali's Sagittarius with Jupiter frequency"
 
 # Sagittarius
 
+![Sagittarius](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/sagittarius.PNG)
+
 > **Grail #7321** · Zodiac · [Browse all Grails →](../browse/grails.md)
 
 Inspired by Dali's Sagittarius. 183.58 planetary Hz of ruling planet Jupiter reflected in faint background scribbles.

--- a/grails/satanist.md
+++ b/grails/satanist.md
@@ -8,6 +8,8 @@ description: "Leila Waddell inspired with Thoth Lust tarot and occult sigils"
 
 # Satanist
 
+![Satanist](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/satanist.PNG)
+
 > **Grail #8557** · Ancestor · [Browse all Grails →](../browse/grails.md)
 
 Leila Waddell inspired piece. Thoth Lust tarot background. Sigil of Baphomet and Temple of Set symbols on background. Leviathan, Sigil of Lilith, Seal of Babalon on violin.

--- a/grails/satoshi-as-hermes.md
+++ b/grails/satoshi-as-hermes.md
@@ -8,6 +8,8 @@ description: "Satoshi as Hermes, inspired by the Lugano statue"
 
 # Satoshi as Hermes
 
+![Satoshi as Hermes](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/satoshi.png)
+
 > **Grail #4488** · Special · [Browse all Grails →](../browse/grails.md)
 
 Satoshi as Hermes, inspired by the statue of Satoshi in Lugano. There are some messages here.

--- a/grails/saturn.md
+++ b/grails/saturn.md
@@ -8,6 +8,8 @@ description: "Goya's Saturn Devouring His Son — cfang as Saturn"
 
 # Saturn
 
+![Saturn](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/saturn.png)
+
 > **Grail #7388** · Planet · [Browse all Grails →](../browse/grails.md)
 
 Saturn Devouring His Son Goya painting reference. Cfang as Saturn, Milady Mfers as son, as representative of Milady derivatives.

--- a/grails/scorpio.md
+++ b/grails/scorpio.md
@@ -8,6 +8,8 @@ description: "Kali as Scorpio — scorpion, eagle, phoenix journey"
 
 # Scorpio
 
+![Scorpio](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/scorpio.png)
+
 > **Grail #235** · Zodiac · [Browse all Grails →](../browse/grails.md)
 
 Kali as Scorpio. Scorpion item, eagle feather earrings, background reminiscent of a phoenix — communicates the Scorpio journey. Cfang severed head, destruction of ego.

--- a/grails/sun.md
+++ b/grails/sun.md
@@ -8,6 +8,8 @@ description: "Radiate crown of resurrection with 126.22 Hz solar frequency"
 
 # Sun
 
+![Sun](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/sun.PNG)
+
 > **Grail #3116** · Luminary · [Browse all Grails →](../browse/grails.md)
 
 8-pronged radiate crown to signify resurrection. 126.22 Hz planetary frequency displayed in the background and repeated in order to illustrate how the sun's energy travels. Colors are meant to be reminiscent of how it looks to look at the sun through closed eyes.

--- a/grails/taurus.md
+++ b/grails/taurus.md
@@ -8,6 +8,8 @@ description: "Femme Dionysus as Taurus with Mercury and the Nymphs reference"
 
 # Taurus
 
+![Taurus](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/taurus.PNG)
+
 > **Grail #2113** · Zodiac · [Browse all Grails →](../browse/grails.md)
 
 Femme Dionysus as Taurus. Mercury Entrusting Bacchus to the Nymphs painting in background. Poppies in foreground.

--- a/grails/uranus.md
+++ b/grails/uranus.md
@@ -8,6 +8,8 @@ description: "The sky, soundwaves"
 
 # Uranus
 
+![Uranus](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/uranus.png)
+
 > **Grail #7916** · Primordial · [Browse all Grails →](../browse/grails.md)
 
 > **Combined piece**: When Uranus is placed on top of Gaia, they form a single unified artwork.

--- a/grails/venus.md
+++ b/grails/venus.md
@@ -8,6 +8,8 @@ description: "Inanna as Venus holding lion cub, 221.23 Hz frequency"
 
 # Venus
 
+![Venus](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/venus.png)
+
 > **Grail #4617** · Planet · [Browse all Grails →](../browse/grails.md)
 
 Inanna as Venus. Holding lion cub to represent fertility. Venus 221.23 Hz planetary frequency visual in background.

--- a/grails/virgo.md
+++ b/grails/virgo.md
@@ -8,6 +8,8 @@ description: "Persephone as Virgo with pomegranate and Mercury nervous system"
 
 # Virgo
 
+![Virgo](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/virgo.png)
+
 > **Grail #8834** · Zodiac · [Browse all Grails →](../browse/grails.md)
 
 Persephone as Virgo. Holding pomegranate. Wheat sprigs in hair to signify both Demeter and the Virgo sheaf of grain. 141.27 planetary Hz of ruling planet Mercury reflected in flow of background pattern. Background inspired by Alex Grey's work. Nervous system focus represented on body, Mercury rules the nervous system. Green and gold, harvest and wealth. Neglecting red to showcase virginal purity.

--- a/grails/water.md
+++ b/grails/water.md
@@ -8,6 +8,8 @@ description: "Aquatic hues with downward flow and chest light evoking the sun"
 
 # Water
 
+![Water](https://gateway.irys.xyz/7rpvwFYcB5t7S1HziaBAr4RgfAFpqCwCYbFUbkFqpbAq/water.PNG)
+
 > **Grail #6761** · Element · [Browse all Grails →](../browse/grails.md)
 
 All hues associated with water. Downward flowing, water falls with gravity. Presence of light in the chest to evoke connection to the sun, providing life.


### PR DESCRIPTION
## Summary
- Adds embedded Irys gateway images to all 42 canonical Grail markdown files
- Each Grail now displays its hand-drawn 1/1 artwork directly in the page via `![title](https://gateway.irys.xyz/...)`
- Images placed consistently after the `# Title` heading, before the Grail description block

## Details
- 42 files changed, 84 insertions (2 lines per file: image + blank line)
- Images hosted on Irys permanent storage, referenced via gateway URLs
- No frontmatter or backlink changes

## Test plan
- [ ] Verify images render correctly on GitHub for a sample of Grail pages
- [ ] Confirm no broken links via `audit-links.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)