### PR TITLE
feat: add short_description for storefront tagline

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -4,6 +4,7 @@ slug: mibera-codex
 version: 1.0.0
 construct_type: codex
 description: "Complete knowledge base for the Mibera universe — 10,000 generative NFTs on Berachain with 1,337 traits, 78 drugs mapped to tarot, 33 ancestors, and 15,000 years of lore"
+short_description: "Mibera universe knowledge"
 domain:
   - documentation
 author: 0xHoneyJar


### PR DESCRIPTION
Add `short_description` field to `construct.yaml` for constructs.network catalog display.

Tagline: **Mibera universe knowledge**

Part of 0xHoneyJar/loa-constructs#157

🤖 Generated with [Claude Code](https://claude.com/claude-code)