### PR TITLE
chore: add standard type field to construct manifest

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -3,6 +3,7 @@ name: "Mibera Codex"
 slug: mibera-codex
 version: 1.0.0
 construct_type: codex
+type: codex
 description: "Complete knowledge base for the Mibera universe — 10,000 generative NFTs on Berachain with 1,337 traits, 78 drugs mapped to tarot, 33 ancestors, and 15,000 years of lore"
 short_description: "Mibera universe knowledge"
 domain:


### PR DESCRIPTION
## Summary
- Adds `type: codex` — standard type field for registry consistency alongside existing `construct_type: codex`

## Why
Part of the ecosystem-wide metadata normalization. The standard field name across the ecosystem is `type:` (used by protocol, vocabulary-bank, gecko, etc.). Mibera Codex used the non-standard `construct_type` field. Both are preserved for backwards compatibility.

Already has `visibility: public` and `domain: [documentation]`. No composition fields added — mibera-codex is correctly isolated (knowledge base, no cross-construct grimoire I/O).

## Test plan
- [ ] `yq eval '.' construct.yaml` parses without error
- [ ] Fields are additive only — no existing fields modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)