### PR TITLE
feat: add capability metadata for runtime routing

### DIFF
--- a/construct.yaml
+++ b/construct.yaml
@@ -28,6 +28,17 @@ commands:
     path: commands/codex.md
     description: "Query the Mibera knowledge base"
 
+capabilities:
+  model_tier: haiku
+  danger_level: safe
+  effort_hint: small
+  downgrade_allowed: true
+  execution_hint: parallel
+  requires:
+    tool_calling: true
+    thinking_traces: false
+    vision: false
+
 identity:
   persona: identity/persona.yaml
   expertise: identity/expertise.yaml


### PR DESCRIPTION
## Summary
- Add capabilities stanza for runtime model routing
- model_tier: haiku, danger_level: safe, effort_hint: small

## Changes
- `construct.yaml`: capabilities metadata added

## Context
Network audit (2026-03-17) found 21/22 constructs had no capability metadata.
Runtime routing uses these fields to select appropriate model tier, estimate cost, and determine execution strategy.

Mibera Codex is a read-only knowledge base — haiku tier with parallel execution is optimal for lookup queries.

```yaml
capabilities:
  model_tier: haiku
  danger_level: safe
  effort_hint: small
  downgrade_allowed: true
  execution_hint: parallel
  requires:
    tool_calling: true
    thinking_traces: false
    vision: false
```