### PR TITLE
feat: codex-mcp v1 — 8-tool MCP server (closes #53)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,13 @@ grimoires/loa/NOTES.md.tmp
 grimoires/loa/analytics/
 grimoires/loa/a2a/trajectory/
 grimoires/loa/memory/
+
+# codex-mcp build + secrets
+dist/
+*.tsbuildinfo
+.env
+.env.local
+.env.*.local
+
+# codex-mcp coverage-gap log — curator review surface, not for git tracking
+grimoires/codex-mcp/coverage-gaps.jsonl

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 *Documentation for Mibera Maker — 10,000 time-travelling Rebased Retard Beras carrying the eternal flame of the Rave.*
 
+> 📡 **codex-mcp v1** ships from this repo (Path A · stdio). Eight tools for narrative-bot consumers: `lookup_zone`, `lookup_archetype`, `lookup_factor`, `lookup_grail`, `lookup_mibera`, `list_zones`, `list_archetypes`, `validate_world_element`. See [§ codex-mcp](#-codex-mcp-anti-hallucination-lookup) below.
+
 ---
 
 > *"Milady has to die, so that Milady may live. Milady lost her way. And in ego death, she finds Mibera."*
@@ -103,6 +105,75 @@ Explore the 10,000 Miberas through faceted search — filter by archetype, ances
 | Tarot-Drug Mappings | 78 |
 | Ecosystem Contracts | 11 |
 | Birthday Range | 13,166 BCE – 2024 CE |
+
+---
+
+## 📡 codex-mcp — anti-hallucination lookup
+
+The codex ships an MCP server for narrative-bot consumers (freeside-characters' ruggy + satoshi today, future puruhani daemons). It is the **read interface** to the codex's canonical world-elements.
+
+Per [RFC #53](https://github.com/0xHoneyJar/construct-mibera-codex/issues/53) and Gumi's locked v1 design (2026-04-29):
+
+| Tool | What it returns |
+|---|---|
+| `lookup_zone(slug)` | Full zone — archetype, era, essence, Lynch primitives, KANSEI tokens |
+| `lookup_archetype(name)` | One of the 4 — era, zodiac, season, locations, figures, events, drugs, ancestors, fashion |
+| `lookup_factor(factor_id)` | Cross-construct JOIN with score-mibera — display name, dimension, archetype anchor, lore, status |
+| `lookup_grail(query)` | Grail by ID, slug, or name — name, category, description, status |
+| `lookup_mibera(id)` | Single Mibera by ID (1-10000) — full canonical trait set |
+| `list_zones()` | All zone summaries |
+| `list_archetypes()` | All 4 archetype summaries |
+| `validate_world_element(type, value)` | Canonical check + suggested-closest fuzzy match. Logs unmatched-but-Mibera-relevant queries to `grimoires/codex-mcp/coverage-gaps.jsonl` for periodic curator review |
+
+### Run locally
+
+```bash
+pnpm install
+pnpm mcp           # stdio server on stdin/stdout
+```
+
+Add to Claude Code (`.claude/settings.json` or `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "codex": {
+      "command": "pnpm",
+      "args": ["--prefix", "/path/to/construct-mibera-codex", "mcp"]
+    }
+  }
+}
+```
+
+### Source of truth
+
+| Tool | Reads from |
+|---|---|
+| `lookup_zone` / `list_zones` | `core-lore/festival-zones-vocabulary.md` |
+| `lookup_archetype` / `list_archetypes` | `core-lore/archetypes.md` |
+| `lookup_factor` | `core-lore/factor-lore.md` |
+| `lookup_grail` | `_codex/data/grails.jsonl` |
+| `lookup_mibera` | `_codex/data/miberas.jsonl` |
+
+The codex repo IS the SoT (per Gumi D3). Rolling latest, no semver tags (per C4) — commits land continuously.
+
+### Coverage gap log
+
+When `validate_world_element` returns `{ canonical: false }`, the (type, value, suggestion) is appended to `grimoires/codex-mcp/coverage-gaps.jsonl` (gitignored — local-only review surface). This is Gumi's curator queue: unmatched-but-Mibera-relevant queries that hint at codex gaps.
+
+### Anti-hallucination tier model
+
+Per `beacon.yaml.mcp.tiers`:
+
+- **🔒 HARD** — substrate enforces, LLM cannot escape (zone slug/emoji/archetype, archetype canonical names, factor IDs, mibera IDs, grail IDs)
+- **🪶 SOFT** — MCP provides reference, LLM has creative license over composition (zone essence, KANSEI texture, archetype figures/events/fashion, factor lore)
+- **🌀 LLM-OWNED** — no MCP involvement (narrator voice, activity-class words, closing observations)
+
+Consumer guards (e.g., score-mibera `hallucination-guard.ts`) validate generated narrative against the HARD set before delivery.
+
+### Doctrine
+
+Implements `constructs-mcp-shape` + `constructs-mcp-deployment-topology` from operator's vault. Path A (stdio) ships in this repo. Path B (self-hosted Streamable HTTP) is a follow-on cycle when production bot deploy demands it.
 
 ---
 

--- a/beacon.yaml
+++ b/beacon.yaml
@@ -1,0 +1,75 @@
+# Beacon MCP declaration for construct-mibera-codex
+# Generated following the constructs-mcp-shape doctrine
+# (see vault: constructs-mcp-shape, constructs-mcp-deployment-topology)
+
+mcp:
+  shape: data
+  paths:
+    - stdio
+  remote:
+    transport: streamable-http
+    endpoint: ${MCP_REMOTE_ENDPOINT}  # Path B: set when self-hosting
+  tools:
+    - lookup_zone
+    - lookup_archetype
+    - lookup_factor
+    - lookup_grail
+    - lookup_mibera
+    - list_zones
+    - list_archetypes
+    - validate_world_element
+  source_of_truth:
+    type: git_repo
+    files:
+      - core-lore/festival-zones-vocabulary.md
+      - core-lore/archetypes.md
+      - core-lore/factor-lore.md
+      - _codex/data/grails.jsonl
+      - _codex/data/miberas.jsonl
+  tiers:
+    hard:
+      - zone.slug
+      - zone.emoji
+      - zone.archetype
+      - archetype.name
+      - archetype.zodiac_signs
+      - archetype.season
+      - factor.id
+      - factor.dimension
+      - mibera.id
+      - mibera.archetype
+      - mibera.ancestor
+      - grail.id
+      - grail.name
+      - grail.category
+    soft:
+      - zone.essence
+      - zone.lynch_primitives
+      - zone.kansei_tokens
+      - archetype.figures
+      - archetype.events
+      - archetype.fashion
+      - factor.lore
+    llm_owned:
+      - narrator_voice
+      - activity_class_word
+      - closing_observation
+  payment:
+    enabled: false   # x402 wrapping deferred to v2
+
+# v2 deferred:
+# - lookup_ancestor (33 ancestors in core-lore/ancestors/)
+# - lookup_trait (1,337 traits in traits/)
+# - lookup_drug (78 in traits/overlays/molecules/)
+# - lookup_tarot (78 in core-lore/tarot-cards/)
+# - write events (read-only at v1 per Gumi D3)
+# - registry-gateway hosting (Path C)
+
+# v1 design verdicts: see construct-mibera-codex#53 (Gumi 2026-04-29)
+# - D1/D2/D3 doctrines locked
+# - C1: ship 7 + lookup_mibera (= 8 tools) — done
+# - C2: hybrid JSON + optional markdown response — done
+# - C3: validate_world_element returns suggested-closest — done
+# - C4: rolling latest, no semver tags
+# - C5: graceful degradation (consumer-side)
+# - C6: coverage gap log (grimoires/codex-mcp/coverage-gaps.jsonl) — done

--- a/bin/mcp.ts
+++ b/bin/mcp.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createCodexMcpServer } from "../src/server.js";
+
+async function main(): Promise<void> {
+  const server = createCodexMcpServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  process.stderr.write("[codex-mcp] stdio server ready\n");
+}
+
+main().catch((err) => {
+  process.stderr.write(`[codex-mcp] fatal: ${err.stack ?? err.message ?? err}\n`);
+  process.exit(1);
+});

--- a/construct.yaml
+++ b/construct.yaml
@@ -1,11 +1,11 @@
 schema_version: 3
 name: "Mibera Codex"
 slug: mibera-codex
-version: 1.0.0
+version: 1.1.0
 construct_type: codex
 type: codex
-description: "Lore database for Mibera NFTs. Query and browse 10,000 digital identities across 7 dimensions (archetype, ancestor, element, tarot, era, molecule, swag rank). Cross-reference trait connections and look up canonical data."
-short_description: "Mibera identity knowledge base"
+description: "Lore database for Mibera NFTs. Query and browse 10,000 digital identities across 7 dimensions (archetype, ancestor, element, tarot, era, molecule, swag rank). Cross-reference trait connections and look up canonical data. Ships an MCP server (stdio) for narrative-bot consumers — anti-hallucination lookup for zones, archetypes, factors, grails, and miberas with fuzzy validation + coverage-gap logging."
+short_description: "Mibera identity knowledge base + codex-mcp"
 domain:
   - documentation
 author: 0xHoneyJar
@@ -27,6 +27,22 @@ commands:
   - name: codex
     path: commands/codex.md
     description: "Query the Mibera knowledge base"
+
+mcp:
+  shape: data
+  paths:
+    - stdio
+  entry: bin/mcp.ts
+  declaration: beacon.yaml
+  tools:
+    - lookup_zone
+    - lookup_archetype
+    - lookup_factor
+    - lookup_grail
+    - lookup_mibera
+    - list_zones
+    - list_archetypes
+    - validate_world_element
 
 capabilities:
   model_tier: haiku

--- a/core-lore/factor-lore.md
+++ b/core-lore/factor-lore.md
@@ -1,0 +1,285 @@
+---
+title: Factor → Lore Mapping
+description: Canonical factor IDs (emitted by score-mibera) mapped to Mibera-codex lore for narrator-bot consumption.
+seeded_by: operator (zksoju)
+seeded_at: 2026-04-30
+status: operator-seeded · curator-pending
+curator: gumi
+load_bearing: true
+---
+
+# Factor → Lore
+
+Score-mibera emits factor IDs (`og:jani_keys`, `nft:mibera`, `onchain:milady_burner`, etc.) as machine labels for on-chain activity. Narrator bots (ruggy, satoshi, future puruhani daemons) need to translate these into Mibera-world lore: which archetype the factor anchors, what cultural register it carries, what the activity *means* in the world.
+
+This file is the canonical join table — the codex side of `score-mibera` ↔ `construct-mibera-codex`. `mcp__codex__lookup_factor(factor_id)` reads from here.
+
+## Editorial authority
+
+Gumi is the SoT for factor lore. The seeded entries below were extracted from `freeside-characters/apps/character-ruggy/codex-anchors.md` (operator-curated interim) and from the score-mibera factor list at `src/lib/midi/unified-factor-config.ts`. They are **starting points, not finished**. Curate freely.
+
+## Status field
+
+Per `score-mibera#72`: factors with `weight: 0` in score config are folded into multipliers and should carry `status: "historic"` or `"merged"` here. Live factors carry `status: "live"` (default).
+
+---
+
+## OG dimension
+
+### og:jani_keys
+
+- **dimension**: `og`
+- **archetype**: All (pre-archetype — foundational team era)
+- **status**: live
+- **display_name**: Jani Keys
+- **lore**: 🪶 **TODO (Gumi)** — the Honey Jar Genesis Keys minted by Jani's pre-Mibera era. Cultural register: founder lineage, builder credentials, "before the rave."
+
+### og:cfang_keys
+
+- **dimension**: `og`
+- **archetype**: Milady
+- **status**: live
+- **display_name**: Cfang Keys
+- **lore**: 🪶 **TODO (Gumi)** — Charlotte Fang / Remilia keys. Cultural register: network spirituality, post-ironic aspiration, "the screen as altar."
+
+### og:articles
+
+- **dimension**: `og`
+- **archetype**: All
+- **status**: live
+- **display_name**: Articles
+- **lore**: 🪶 **TODO (Gumi)** — written-form OG signal. Cultural register: chronicler / lore-keeper, "the rave gets written down."
+
+### og:sets
+
+- **dimension**: `og`
+- **archetype**: Chicago/Detroit
+- **status**: live
+- **display_name**: DJ Sets
+- **lore**: 🪶 **TODO (Gumi)** — recorded mixes / sets archive. Cultural register: Ron Hardy at the Music Box, "the genre is named after this room."
+
+### og:cubquest
+
+- **dimension**: `og`
+- **archetype**: Freetekno
+- **status**: live
+- **display_name**: CubQuest
+- **lore**: 🪶 **TODO (Gumi)** — quest engine OG participation. Cultural register: muddy ruts between rigs, "the rig hasn't stopped since Thursday."
+
+---
+
+## NFT dimension
+
+### nft:mibera
+
+- **dimension**: `nft`
+- **archetype**: All (depends on the specific Mibera)
+- **status**: live
+- **display_name**: Mibera NFT
+- **lore**: 🪶 **TODO (Gumi)** — the foundational holding. Cultural register: 10,000 time-travelling Beras carrying the eternal flame of the rave; the shadow side of Milady; ravepill, sweaty filthy reality of the dance floor.
+
+### nft:mibera_quality
+
+- **dimension**: `nft`
+- **archetype**: All
+- **status**: historic
+- **display_name**: Mibera Quality
+- **lore**: 🪶 **TODO (Gumi)** — folded into `nft:mibera` as a quality_score multiplier. Per score-mibera#72: surface as historic so list_factors hides it from live consumers.
+
+### nft:fractures
+
+- **dimension**: `nft`
+- **archetype**: Milady
+- **status**: live
+- **display_name**: Fractures
+- **lore**: 🪶 **TODO (Gumi)** — Fracture pieces / Milady fragment collection. Cultural register: el-dorado bazaar, "the treasure is real but the map keeps changing."
+
+### nft:fractures_complete
+
+- **dimension**: `nft`
+- **archetype**: Milady
+- **status**: historic
+- **display_name**: Complete Fracture Sets
+- **lore**: 🪶 **TODO (Gumi)** — folded into `nft:fractures` quality multiplier. Per score-mibera#72: historic.
+
+---
+
+## Onchain dimension
+
+### onchain:miberamaker
+
+- **dimension**: `onchain`
+- **archetype**: All
+- **status**: live
+- **display_name**: Mibera Maker
+- **lore**: 🪶 **TODO (Gumi)** — the maker contract that mints grails / 1/1s. Cultural register: builder's bench, "the artist commissioning their own commissioning."
+
+### onchain:validator_booster
+
+- **dimension**: `onchain`
+- **archetype**: Chicago/Detroit
+- **status**: live
+- **display_name**: Validator Booster
+- **lore**: 🪶 **TODO (Gumi)** — Berachain validator boosting. Cultural register: foundational infra, "undecorated, undeniable, foundational."
+
+### onchain:candies_minter
+
+- **dimension**: `onchain`
+- **archetype**: Freetekno
+- **status**: live
+- **display_name**: Candies Minter
+- **lore**: 🪶 **TODO (Gumi)** — Honey Candies minting. Cultural register: rig-running, sticky sweet, "tea + speed and someone's dog asleep by the fire barrel."
+
+### onchain:gif_minter
+
+- **dimension**: `onchain`
+- **archetype**: Milady
+- **status**: live
+- **display_name**: GIF Minter
+- **lore**: 🪶 **TODO (Gumi)** — animated frame collector. Cultural register: notification chimes layered over hyperpop.
+
+### onchain:tarot_minter
+
+- **dimension**: `onchain`
+- **archetype**: Acidhouse
+- **status**: live
+- **display_name**: Tarot Minter
+- **lore**: 🪶 **TODO (Gumi)** — drug-tarot card mints. Cultural register: owsley-lab synthesis floor, "PiHKAL on the centrifuge, periodic table on the wall."
+
+### onchain:zora_collector
+
+- **dimension**: `onchain`
+- **archetype**: Milady
+- **status**: live
+- **display_name**: Zora Collector
+- **lore**: 🪶 **TODO (Gumi)** — Zora-network collector activity. Cultural register: el-dorado bazaar, "everything glows and everything's for sale."
+
+### onchain:beraji_staker
+
+- **dimension**: `onchain`
+- **archetype**: Chicago/Detroit
+- **status**: live
+- **display_name**: Beraji Staker
+- **lore**: 🪶 **TODO (Gumi)** — Beraji staking participation. Cultural register: foundational protocol commitment.
+
+### onchain:shadow_minter
+
+- **dimension**: `onchain`
+- **archetype**: Acidhouse
+- **status**: live
+- **display_name**: Shadow Minter
+- **lore**: 🪶 **TODO (Gumi)** — shadow / off-glance mints. Cultural register: "everything hums at 440Hz," the unseen layer.
+
+### onchain:milady_burner
+
+- **dimension**: `onchain`
+- **archetype**: Milady
+- **status**: live
+- **display_name**: Milady Burner
+- **lore**: 🪶 **TODO (Gumi)** — burning Milady-adjacent assets. Cultural register: ritual destruction, the wartime aesthetic.
+
+### onchain:mibera_burner
+
+- **dimension**: `onchain`
+- **archetype**: All
+- **status**: live
+- **display_name**: Mibera Burner
+- **lore**: 🪶 **TODO (Gumi)** — burning miberas. Cultural register: ceremonial removal, "the rave clears its own floor."
+
+### onchain:cubquest_minter
+
+- **dimension**: `onchain`
+- **archetype**: Freetekno
+- **status**: live
+- **display_name**: CubQuest Minter
+- **lore**: 🪶 **TODO (Gumi)** — quest reward / mint participation. Cultural register: stamp on the journey, "the wristband from the festival."
+
+### onchain:liquid_backing
+
+- **dimension**: `onchain`
+- **archetype**: All
+- **status**: live
+- **display_name**: Liquid Backing
+- **lore**: 🪶 **TODO (Gumi)** — protocol-owned liquidity participation. Cultural register: structural commitment, "the building was a factory, then it was nothing."
+
+### onchain:loan_taker
+
+- **dimension**: `onchain`
+- **archetype**: Acidhouse
+- **status**: live
+- **display_name**: Loan Taker
+- **lore**: 🪶 **TODO (Gumi)** — borrower against on-chain assets. Cultural register: leveraged risk, "time-dilation, the 20-minute track."
+
+### onchain:loan_defaulter
+
+- **dimension**: `onchain`
+- **archetype**: Acidhouse
+- **status**: live
+- **display_name**: Loan Defaulter
+- **lore**: 🪶 **TODO (Gumi)** — defaulted positions. Cultural register: cautionary lore, the come-down.
+
+### onchain:liquidator
+
+- **dimension**: `onchain`
+- **archetype**: Freetekno
+- **status**: live
+- **display_name**: Liquidator
+- **lore**: 🪶 **TODO (Gumi)** — liquidation participants. Cultural register: enforcement, "the rig calls for clearance."
+
+### onchain:paddle_supplier
+
+- **dimension**: `onchain`
+- **archetype**: All
+- **status**: live
+- **display_name**: Paddle Supplier
+- **lore**: 🪶 **TODO (Gumi)** — Paddle protocol liquidity supplier.
+
+### onchain:paddle_borrower
+
+- **dimension**: `onchain`
+- **archetype**: All
+- **status**: live
+- **display_name**: Paddle Borrower
+- **lore**: 🪶 **TODO (Gumi)** — Paddle protocol borrower.
+
+### onchain:paddle_liquidated
+
+- **dimension**: `onchain`
+- **archetype**: All
+- **status**: live
+- **display_name**: Paddle Liquidated
+- **lore**: 🪶 **TODO (Gumi)** — Paddle position liquidated.
+
+### onchain:paddle_liquidator
+
+- **dimension**: `onchain`
+- **archetype**: All
+- **status**: live
+- **display_name**: Paddle Liquidator
+- **lore**: 🪶 **TODO (Gumi)** — Paddle liquidation enforcer.
+
+---
+
+## How this is read
+
+Parsed by `src/lookups/factor.ts` — h3 (`### {factor_id}`) is the key, the bullet list under it is the lore body. Free-form prose under each entry is preserved verbatim in `lore` field.
+
+When a consumer calls `mcp__codex__lookup_factor(factor_id)`:
+
+```ts
+{
+  id: "og:jani_keys",
+  display_name: "Jani Keys",
+  dimension: "og",
+  archetype: "All",
+  lore: "🪶 TODO (Gumi) — the Honey Jar Genesis Keys minted by Jani's pre-Mibera era...",
+  codex_anchor: "core-lore/factor-lore.md#ogjani_keys",
+  status: "live"
+}
+```
+
+When the operator's interim translations in `freeside-characters/apps/character-ruggy/codex-anchors.md` are made obsolete by curated entries here, that file deletes (per [score-mibera#70 migration plan](https://github.com/0xHoneyJar/score-mibera/issues/70)).
+
+## Coverage gaps
+
+`mcp__codex__validate_world_element({type: "factor", value: "..."})` logs unmatched-but-Mibera-relevant queries to `grimoires/codex-mcp/coverage-gaps.jsonl` per Gumi's C6 ask. Periodic review surfaces what's missing while the codex is still being built out.

--- a/core-lore/factor-lore.md
+++ b/core-lore/factor-lore.md
@@ -1,5 +1,5 @@
 ---
-title: Factor → Lore Mapping
+title: "Factor \u2192 Lore Mapping"
 description: Canonical factor IDs (emitted by score-mibera) mapped to Mibera-codex lore for narrator-bot consumption.
 seeded_by: operator (zksoju)
 seeded_at: 2026-04-30
@@ -32,15 +32,14 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: All (pre-archetype — foundational team era)
 - **status**: live
 - **display_name**: Jani Keys
-- **lore**: 🪶 **TODO (Gumi)** — the Honey Jar Genesis Keys minted by Jani's pre-Mibera era. Cultural register: founder lineage, builder credentials, "before the rave."
-
+- **lore**: Jani's Friendtech Keys. If you had one, you likely obtained one in order to get mibera WL.
 ### og:cfang_keys
 
 - **dimension**: `og`
 - **archetype**: Milady
 - **status**: live
 - **display_name**: Cfang Keys
-- **lore**: 🪶 **TODO (Gumi)** — Charlotte Fang / Remilia keys. Cultural register: network spirituality, post-ironic aspiration, "the screen as altar."
+- **lore**: Cfang's Friendtech Keys. If you had one, you likely obtained one in order to get mibera WL.
 
 ### og:articles
 
@@ -48,15 +47,15 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: All
 - **status**: live
 - **display_name**: Articles
-- **lore**: 🪶 **TODO (Gumi)** — written-form OG signal. Cultural register: chronicler / lore-keeper, "the rave gets written down."
+- **lore**: Written-form OG signal. Long-form pieces which documented the culture while it was being built. 
 
 ### og:sets
 
 - **dimension**: `og`
-- **archetype**: Chicago/Detroit
+- **archetype**: All
 - **status**: live
-- **display_name**: DJ Sets
-- **lore**: 🪶 **TODO (Gumi)** — recorded mixes / sets archive. Cultural register: Ron Hardy at the Music Box, "the genre is named after this room."
+- **display_name**: Mibera Sets
+- **lore**: A collection of articles, posters, and music - later represented by pieces of art minted on Optimism. Predates Mibera mainstem. 
 
 ### og:cubquest
 
@@ -64,7 +63,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: Freetekno
 - **status**: live
 - **display_name**: CubQuest
-- **lore**: 🪶 **TODO (Gumi)** — quest engine OG participation. Cultural register: muddy ruts between rigs, "the rig hasn't stopped since Thursday."
+- **lore**: Quest engine OG participation. Showed up when the coordinates dropped and there was nothing but a field and a sound system. You were there.
 
 ---
 
@@ -76,7 +75,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: All (depends on the specific Mibera)
 - **status**: live
 - **display_name**: Mibera NFT
-- **lore**: 🪶 **TODO (Gumi)** — the foundational holding. Cultural register: 10,000 time-travelling Beras carrying the eternal flame of the rave; the shadow side of Milady; ravepill, sweaty filthy reality of the dance floor.
+- **lore**: The foundational holding. 10,000 Miberas built from 1337 traits total - each with an archetype, ancestor, birthday, and signal hierarchy. Hand-painted on iPad in Procreate over 18 months. 
 
 ### nft:mibera_quality
 
@@ -84,23 +83,23 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: All
 - **status**: historic
 - **display_name**: Mibera Quality
-- **lore**: 🪶 **TODO (Gumi)** — folded into `nft:mibera` as a quality_score multiplier. Per score-mibera#72: surface as historic so list_factors hides it from live consumers.
+- **lore**: Folded into `nft:mibera` as a multiplier. Swag score still exists per Mibera, just not counted separately anymore.
 
 ### nft:fractures
 
 - **dimension**: `nft`
-- **archetype**: Milady
+- **archetype**: All
 - **status**: live
 - **display_name**: Fractures
-- **lore**: 🪶 **TODO (Gumi)** — Fracture pieces / Milady fragment collection. Cultural register: el-dorado bazaar, "the treasure is real but the map keeps changing."
+- **lore**: Fracture pieces from the Mibera reveal. 11 phases, each exposing more of the character underneath. Shards of a larger image that only made sense in sequence.
 
 ### nft:fractures_complete
 
 - **dimension**: `nft`
-- **archetype**: Milady
+- **archetype**: All
 - **status**: historic
 - **display_name**: Complete Fracture Sets
-- **lore**: 🪶 **TODO (Gumi)** — folded into `nft:fractures` quality multiplier. Per score-mibera#72: historic.
+- **lore**: Folded into `nft:fractures` as a quality multiplier. Completeness used to be its own signal.
 
 ---
 
@@ -112,7 +111,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: All
 - **status**: live
 - **display_name**: Mibera Maker
-- **lore**: 🪶 **TODO (Gumi)** — the maker contract that mints grails / 1/1s. Cultural register: builder's bench, "the artist commissioning their own commissioning."
+- **lore**: The maker contract. Where grails and 1-of-1s get minted. 43 hand-drawn pieces with cultural context.
 
 ### onchain:validator_booster
 
@@ -120,7 +119,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: Chicago/Detroit
 - **status**: live
 - **display_name**: Validator Booster
-- **lore**: 🪶 **TODO (Gumi)** — Berachain validator boosting. Cultural register: foundational infra, "undecorated, undeniable, foundational."
+- **lore**: Berachain validator boosting. Foundational infrastructure. The warehouse doesn't need a sign.
 
 ### onchain:candies_minter
 
@@ -128,7 +127,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: Freetekno
 - **status**: live
 - **display_name**: Candies Minter
-- **lore**: 🪶 **TODO (Gumi)** — Honey Candies minting. Cultural register: rig-running, sticky sweet, "tea + speed and someone's dog asleep by the fire barrel."
+- **lore**: Honey Candies minting. Sticky sweet, passed hand to hand. Tea stall energy.
 
 ### onchain:gif_minter
 
@@ -136,7 +135,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: Milady
 - **status**: live
 - **display_name**: GIF Minter
-- **lore**: 🪶 **TODO (Gumi)** — animated frame collector. Cultural register: notification chimes layered over hyperpop.
+- **lore**: Animated frame collecting. Quick-cut, swipe-speed energy. Everything glows, everything moves.
 
 ### onchain:tarot_minter
 
@@ -144,7 +143,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: Acidhouse
 - **status**: live
 - **display_name**: Tarot Minter
-- **lore**: 🪶 **TODO (Gumi)** — drug-tarot card mints. Cultural register: owsley-lab synthesis floor, "PiHKAL on the centrifuge, periodic table on the wall."
+- **lore**: Drug-tarot card mints. 78 cards mapping molecules to divinatory arcana. The owsley-lab synthesis floor.
 
 ### onchain:zora_collector
 
@@ -152,7 +151,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: Milady
 - **status**: live
 - **display_name**: Zora Collector
-- **lore**: 🪶 **TODO (Gumi)** — Zora-network collector activity. Cultural register: el-dorado bazaar, "everything glows and everything's for sale."
+- **lore**: Zora-network collecting. The el-dorado bazaar in protocol form. The treasure is real but the map keeps changing.
 
 ### onchain:beraji_staker
 
@@ -160,7 +159,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: Chicago/Detroit
 - **status**: live
 - **display_name**: Beraji Staker
-- **lore**: 🪶 **TODO (Gumi)** — Beraji staking participation. Cultural register: foundational protocol commitment.
+- **lore**: Beraji staking. Protocol-level commitment. Chosen Few energy — keep showing up, keep the warehouse open.
 
 ### onchain:shadow_minter
 
@@ -168,7 +167,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: Acidhouse
 - **status**: live
 - **display_name**: Shadow Minter
-- **lore**: 🪶 **TODO (Gumi)** — shadow / off-glance mints. Cultural register: "everything hums at 440Hz," the unseen layer.
+- **lore**: Shadow mints from the vending machine. 102 exclusive traits not in the main collection. The unseen layer.
 
 ### onchain:milady_burner
 
@@ -176,7 +175,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: Milady
 - **status**: live
 - **display_name**: Milady Burner
-- **lore**: 🪶 **TODO (Gumi)** — burning Milady-adjacent assets. Cultural register: ritual destruction, the wartime aesthetic.
+- **lore**: Burning Milady-adjacent assets. Wartime aesthetic. MIBERA IS THE REFUSAL — sometimes refusal is combustion.
 
 ### onchain:mibera_burner
 
@@ -184,7 +183,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: All
 - **status**: live
 - **display_name**: Mibera Burner
-- **lore**: 🪶 **TODO (Gumi)** — burning miberas. Cultural register: ceremonial removal, "the rave clears its own floor."
+- **lore**: Burning Miberas. The rave clears its own floor.
 
 ### onchain:cubquest_minter
 
@@ -192,7 +191,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: Freetekno
 - **status**: live
 - **display_name**: CubQuest Minter
-- **lore**: 🪶 **TODO (Gumi)** — quest reward / mint participation. Cultural register: stamp on the journey, "the wristband from the festival."
+- **lore**: Quest reward mints. The wristband from the festival. You followed the coordinates, you earned the mark.
 
 ### onchain:liquid_backing
 
@@ -200,7 +199,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: All
 - **status**: live
 - **display_name**: Liquid Backing
-- **lore**: 🪶 **TODO (Gumi)** — protocol-owned liquidity participation. Cultural register: structural commitment, "the building was a factory, then it was nothing."
+- **lore**: Protocol-owned liquidity. Structural commitment that doesn't announce itself. Concrete under the dance floor.
 
 ### onchain:loan_taker
 
@@ -208,7 +207,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: Acidhouse
 - **status**: live
 - **display_name**: Loan Taker
-- **lore**: 🪶 **TODO (Gumi)** — borrower against on-chain assets. Cultural register: leveraged risk, "time-dilation, the 20-minute track."
+- **lore**: Borrowing against on-chain assets. Leveraged risk. The come-up.
 
 ### onchain:loan_defaulter
 
@@ -216,7 +215,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: Acidhouse
 - **status**: live
 - **display_name**: Loan Defaulter
-- **lore**: 🪶 **TODO (Gumi)** — defaulted positions. Cultural register: cautionary lore, the come-down.
+- **lore**: Defaulted positions. The come-down. Not moral judgment — pharmacokinetics applied to capital.
 
 ### onchain:liquidator
 
@@ -224,7 +223,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: Freetekno
 - **status**: live
 - **display_name**: Liquidator
-- **lore**: 🪶 **TODO (Gumi)** — liquidation participants. Cultural register: enforcement, "the rig calls for clearance."
+- **lore**: Liquidation participation. Enforcement at the perimeter. The tree line where torchlight gives out.
 
 ### onchain:paddle_supplier
 
@@ -232,7 +231,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: All
 - **status**: live
 - **display_name**: Paddle Supplier
-- **lore**: 🪶 **TODO (Gumi)** — Paddle protocol liquidity supplier.
+- **lore**: Paddle protocol liquidity supply. Depth in the pool.
 
 ### onchain:paddle_borrower
 
@@ -240,7 +239,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: All
 - **status**: live
 - **display_name**: Paddle Borrower
-- **lore**: 🪶 **TODO (Gumi)** — Paddle protocol borrower.
+- **lore**: Paddle protocol borrowing. Drawing from the pool.
 
 ### onchain:paddle_liquidated
 
@@ -248,7 +247,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: All
 - **status**: live
 - **display_name**: Paddle Liquidated
-- **lore**: 🪶 **TODO (Gumi)** — Paddle position liquidated.
+- **lore**: Paddle position liquidated. The pool reclaims what the pool provided.
 
 ### onchain:paddle_liquidator
 
@@ -256,7 +255,7 @@ Per `score-mibera#72`: factors with `weight: 0` in score config are folded into 
 - **archetype**: All
 - **status**: live
 - **display_name**: Paddle Liquidator
-- **lore**: 🪶 **TODO (Gumi)** — Paddle liquidation enforcer.
+- **lore**: Paddle liquidation enforcement. Returning the pool to equilibrium.
 
 ---
 
@@ -272,13 +271,13 @@ When a consumer calls `mcp__codex__lookup_factor(factor_id)`:
   display_name: "Jani Keys",
   dimension: "og",
   archetype: "All",
-  lore: "🪶 TODO (Gumi) — the Honey Jar Genesis Keys minted by Jani's pre-Mibera era...",
+  lore: "The Genesis Keys predate the rave itself...",
   codex_anchor: "core-lore/factor-lore.md#ogjani_keys",
   status: "live"
 }
 ```
 
-When the operator's interim translations in `freeside-characters/apps/character-ruggy/codex-anchors.md` are made obsolete by curated entries here, that file deletes (per [score-mibera#70 migration plan](https://github.com/0xHoneyJar/score-mibera/issues/70)).
+When the operator's interim translations in `freeside-characters/apps/character-ruggy/codex-anchors.md` are made obsolete by curated entries here, that file deletes (per score-mibera#70 migration plan).
 
 ## Coverage gaps
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@0xhoneyjar/construct-mibera-codex",
+  "version": "1.1.0",
+  "description": "Mibera Codex MCP server — anti-hallucination lookup for narrative-bot consumers (zones, archetypes, factors, grails, miberas).",
+  "type": "module",
+  "bin": {
+    "codex-mcp": "./bin/mcp.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "mcp": "tsx bin/mcp.ts",
+    "mcp:dev": "tsx watch bin/mcp.ts"
+  },
+  "files": [
+    "bin",
+    "dist",
+    "core-lore",
+    "_codex/data",
+    "_codex/schema"
+  ],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.18.2",
+    "gray-matter": "^4.0.3",
+    "zod": "^3.25.28"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/0xHoneyJar/construct-mibera-codex.git"
+  },
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -4,16 +4,18 @@
   "description": "Mibera Codex MCP server — anti-hallucination lookup for narrative-bot consumers (zones, archetypes, factors, grails, miberas).",
   "type": "module",
   "bin": {
-    "codex-mcp": "./bin/mcp.js"
+    "codex-mcp": "./dist/bin/mcp.js"
   },
   "scripts": {
     "build": "tsc",
     "mcp": "tsx bin/mcp.ts",
-    "mcp:dev": "tsx watch bin/mcp.ts"
+    "mcp:dev": "tsx watch bin/mcp.ts",
+    "prepublishOnly": "tsc"
   },
   "files": [
     "bin",
     "dist",
+    "construct.yaml",
     "core-lore",
     "_codex/data",
     "_codex/schema"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1004 @@
+lockfileVersion: '6.0'
+
+dependencies:
+  '@modelcontextprotocol/sdk':
+    specifier: ^1.18.2
+    version: 1.18.2
+  gray-matter:
+    specifier: ^4.0.3
+    version: 4.0.3
+  zod:
+    specifier: ^3.25.28
+    version: 3.25.28
+
+devDependencies:
+  '@types/node':
+    specifier: ^22.10.0
+    version: 22.10.0
+  tsx:
+    specifier: ^4.19.2
+    version: 4.19.2
+  typescript:
+    specifier: ^5.7.2
+    version: 5.7.2
+
+packages:
+
+  /@esbuild/aix-ppc64@0.23.1:
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.23.1:
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.23.1:
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.23.1:
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.23.1:
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.23.1:
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.23.1:
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.23.1:
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.23.1:
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.23.1:
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.23.1:
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.23.1:
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.23.1:
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.23.1:
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.23.1:
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.23.1:
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.23.1:
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.23.1:
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.23.1:
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.23.1:
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.23.1:
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.23.1:
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.23.1:
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.23.1:
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@modelcontextprotocol/sdk@1.18.2:
+    resolution: {integrity: sha512-beedclIvFcCnPrYgHsylqiYJVJ/CI47Vyc4tY8no1/Li/O8U4BTlJfy6ZwxkYwx+Mx10nrgwSVrA7VBbhh4slg==}
+    engines: {node: '>=18'}
+    dependencies:
+      ajv: 6.15.0
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.28
+      zod-to-json-schema: 3.25.2(zod@3.25.28)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@types/node@22.10.0:
+    resolution: {integrity: sha512-XC70cRZVElFHfIUB40FgZOBbgJYFKKMa5nb9lxcwYstFG/Mi+/Y0bGS+rs6Dmhmkpq4pnNiLiuZAbc02YCOnmA==}
+    dependencies:
+      undici-types: 6.20.0
+    dev: true
+
+  /accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+    dev: false
+
+  /ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+    dev: false
+
+  /argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    dependencies:
+      sprintf-js: 1.0.3
+    dev: false
+
+  /body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+    dev: false
+
+  /call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+    dev: false
+
+  /content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+    dev: false
+
+  /content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+    dev: false
+
+  /cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+    dev: false
+
+  /cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+    dev: false
+
+  /debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: false
+
+  /depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    dev: false
+
+  /ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    dev: false
+
+  /encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
+  /es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
+  /es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+    dev: false
+
+  /esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.23.1
+      '@esbuild/android-arm': 0.23.1
+      '@esbuild/android-arm64': 0.23.1
+      '@esbuild/android-x64': 0.23.1
+      '@esbuild/darwin-arm64': 0.23.1
+      '@esbuild/darwin-x64': 0.23.1
+      '@esbuild/freebsd-arm64': 0.23.1
+      '@esbuild/freebsd-x64': 0.23.1
+      '@esbuild/linux-arm': 0.23.1
+      '@esbuild/linux-arm64': 0.23.1
+      '@esbuild/linux-ia32': 0.23.1
+      '@esbuild/linux-loong64': 0.23.1
+      '@esbuild/linux-mips64el': 0.23.1
+      '@esbuild/linux-ppc64': 0.23.1
+      '@esbuild/linux-riscv64': 0.23.1
+      '@esbuild/linux-s390x': 0.23.1
+      '@esbuild/linux-x64': 0.23.1
+      '@esbuild/netbsd-x64': 0.23.1
+      '@esbuild/openbsd-arm64': 0.23.1
+      '@esbuild/openbsd-x64': 0.23.1
+      '@esbuild/sunos-x64': 0.23.1
+      '@esbuild/win32-arm64': 0.23.1
+      '@esbuild/win32-ia32': 0.23.1
+      '@esbuild/win32-x64': 0.23.1
+    dev: true
+
+  /escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    dev: false
+
+  /esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: false
+
+  /etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+    dev: false
+
+  /eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      eventsource-parser: 3.0.8
+    dev: false
+
+  /express-rate-limit@7.5.1(express@5.2.1):
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+    dependencies:
+      express: 5.2.1
+    dev: false
+
+  /express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extendable: 0.1.1
+    dev: false
+
+  /fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: false
+
+  /fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    dev: false
+
+  /finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    dev: false
+
+  /get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+    dev: false
+
+  /get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+    dev: false
+
+  /get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    dev: true
+
+  /gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
+  /gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+    dev: false
+
+  /has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
+  /hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
+    dev: false
+
+  /http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+    dev: false
+
+  /iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
+
+  /inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: false
+
+  /ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+    dev: false
+
+  /is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+    dev: false
+
+  /isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: false
+
+  /js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+    dev: false
+
+  /json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    dev: false
+
+  /kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
+  /media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+    dev: false
+
+  /mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+    dependencies:
+      mime-db: 1.54.0
+    dev: false
+
+  /ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: false
+
+  /negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+    dev: false
+
+  /on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: false
+
+  /once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    dependencies:
+      wrappy: 1.0.2
+    dev: false
+
+  /parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+    dev: false
+
+  /pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+    dev: false
+
+  /proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    dev: false
+
+  /punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.1.0
+    dev: false
+
+  /range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+    dev: false
+
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
+  /router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: false
+
+  /section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+    dev: false
+
+  /send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    dev: false
+
+  /shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+    dependencies:
+      shebang-regex: 3.0.0
+    dev: false
+
+  /shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+    dev: false
+
+  /side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+    dev: false
+
+  /side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+    dev: false
+
+  /side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+    dev: false
+
+  /sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: false
+
+  /statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+    dev: false
+
+  /tsx@4.19.2:
+    resolution: {integrity: sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.23.1
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+    dev: false
+
+  /typescript@5.7.2:
+    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
+  /undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+    dev: true
+
+  /unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    dependencies:
+      punycode: 2.3.1
+    dev: false
+
+  /vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
+  /which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+    dependencies:
+      isexe: 2.0.0
+    dev: false
+
+  /wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: false
+
+  /zod-to-json-schema@3.25.2(zod@3.25.28):
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+    dependencies:
+      zod: 3.25.28
+    dev: false
+
+  /zod@3.25.28:
+    resolution: {integrity: sha512-/nt/67WYKnr5by3YS7LroZJbtcCBurDKKPBPWWzaxvVCGuG/NOsiKkrjoOhI8mJ+SQUXEbUzeB3S+6XDUEEj7Q==}
+    dev: false

--- a/src/coverage-gaps.ts
+++ b/src/coverage-gaps.ts
@@ -1,0 +1,41 @@
+import { appendFileSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { codexPath } from "./lib/codex-root.js";
+import type { CoverageGap, WorldElementType } from "./types.js";
+
+const DEFAULT_LOG = "grimoires/codex-mcp/coverage-gaps.jsonl";
+
+function logPath(): string {
+  return process.env.COVERAGE_GAP_LOG ?? codexPath(DEFAULT_LOG);
+}
+
+function ensureDir(path: string): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+export function logCoverageGap(
+  type: WorldElementType,
+  value: string,
+  suggested: string | null,
+  distance: number | null,
+  consumerHint?: string,
+): void {
+  const entry: CoverageGap = {
+    ts: new Date().toISOString(),
+    type,
+    value,
+    suggested,
+    distance,
+    consumer_hint: consumerHint,
+  };
+  try {
+    const path = logPath();
+    ensureDir(path);
+    appendFileSync(path, JSON.stringify(entry) + "\n", "utf8");
+  } catch (err) {
+    process.stderr.write(
+      `[codex-mcp] coverage-gap log write failed: ${(err as Error).message}\n`,
+    );
+  }
+}

--- a/src/lib/codex-root.ts
+++ b/src/lib/codex-root.ts
@@ -4,20 +4,31 @@ import { existsSync } from "node:fs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
+function walkUpForRoot(start: string): string | null {
+  let dir = resolve(start);
+  while (true) {
+    if (
+      existsSync(resolve(dir, "construct.yaml")) &&
+      existsSync(resolve(dir, "core-lore"))
+    ) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
 export function locateCodexRoot(): string {
   const fromEnv = process.env.CODEX_ROOT;
   if (fromEnv && existsSync(fromEnv)) return resolve(fromEnv);
 
-  const candidates = [
-    resolve(HERE, "../../"),
-    resolve(HERE, "../"),
-    resolve(process.cwd()),
-  ];
-  for (const c of candidates) {
-    if (existsSync(resolve(c, "construct.yaml")) && existsSync(resolve(c, "core-lore"))) {
-      return c;
-    }
-  }
+  const fromHere = walkUpForRoot(HERE);
+  if (fromHere) return fromHere;
+
+  const fromCwd = walkUpForRoot(process.cwd());
+  if (fromCwd) return fromCwd;
+
   throw new Error(
     `Could not locate codex root. Set CODEX_ROOT env var or run from a directory containing construct.yaml + core-lore/.`,
   );

--- a/src/lib/codex-root.ts
+++ b/src/lib/codex-root.ts
@@ -1,0 +1,28 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export function locateCodexRoot(): string {
+  const fromEnv = process.env.CODEX_ROOT;
+  if (fromEnv && existsSync(fromEnv)) return resolve(fromEnv);
+
+  const candidates = [
+    resolve(HERE, "../../"),
+    resolve(HERE, "../"),
+    resolve(process.cwd()),
+  ];
+  for (const c of candidates) {
+    if (existsSync(resolve(c, "construct.yaml")) && existsSync(resolve(c, "core-lore"))) {
+      return c;
+    }
+  }
+  throw new Error(
+    `Could not locate codex root. Set CODEX_ROOT env var or run from a directory containing construct.yaml + core-lore/.`,
+  );
+}
+
+export function codexPath(...segments: string[]): string {
+  return resolve(locateCodexRoot(), ...segments);
+}

--- a/src/lib/levenshtein.ts
+++ b/src/lib/levenshtein.ts
@@ -1,0 +1,37 @@
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+
+  const prev = new Array<number>(n + 1);
+  const curr = new Array<number>(n + 1);
+  for (let j = 0; j <= n; j++) prev[j] = j;
+
+  for (let i = 1; i <= m; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    for (let j = 0; j <= n; j++) prev[j] = curr[j];
+  }
+  return prev[n];
+}
+
+export function suggestClosest(
+  query: string,
+  candidates: readonly string[],
+  threshold = 4,
+): { match: string; distance: number } | null {
+  const q = query.toLowerCase();
+  let best: { match: string; distance: number } | null = null;
+  for (const c of candidates) {
+    const d = levenshtein(q, c.toLowerCase());
+    if (d <= threshold && (best === null || d < best.distance)) {
+      best = { match: c, distance: d };
+    }
+  }
+  return best;
+}

--- a/src/lib/markdown-parser.ts
+++ b/src/lib/markdown-parser.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+
+export interface H2Section {
+  heading: string;
+  body: string;
+}
+
+export function readMarkdown(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+export function splitH2Sections(markdown: string): H2Section[] {
+  const lines = markdown.split("\n");
+  const sections: H2Section[] = [];
+  let current: H2Section | null = null;
+  let inCodeBlock = false;
+
+  for (const line of lines) {
+    if (line.startsWith("```")) inCodeBlock = !inCodeBlock;
+
+    if (!inCodeBlock && line.startsWith("## ")) {
+      if (current) sections.push(current);
+      current = { heading: line.slice(3).trim(), body: "" };
+      continue;
+    }
+
+    if (current) current.body += line + "\n";
+  }
+  if (current) sections.push(current);
+  return sections;
+}
+
+export function splitH3Sections(markdown: string): H2Section[] {
+  const lines = markdown.split("\n");
+  const sections: H2Section[] = [];
+  let current: H2Section | null = null;
+  let inCodeBlock = false;
+
+  for (const line of lines) {
+    if (line.startsWith("```")) inCodeBlock = !inCodeBlock;
+
+    if (!inCodeBlock && line.startsWith("### ")) {
+      if (current) sections.push(current);
+      current = { heading: line.slice(4).trim(), body: "" };
+      continue;
+    }
+
+    if (current) current.body += line + "\n";
+  }
+  if (current) sections.push(current);
+  return sections;
+}
+
+export interface TableRow {
+  [column: string]: string;
+}
+
+export function parseFirstMarkdownTable(body: string): TableRow[] {
+  const lines = body.split("\n");
+  let headerLine = -1;
+  for (let i = 0; i < lines.length - 1; i++) {
+    if (
+      lines[i].includes("|") &&
+      /^\s*\|[-:\s|]+\|\s*$/.test(lines[i + 1])
+    ) {
+      headerLine = i;
+      break;
+    }
+  }
+  if (headerLine === -1) return [];
+
+  const cols = splitTableRow(lines[headerLine]);
+  const rows: TableRow[] = [];
+  for (let i = headerLine + 2; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.includes("|")) break;
+    if (line.trim() === "") break;
+    const cells = splitTableRow(line);
+    if (cells.length === 0) continue;
+    const row: TableRow = {};
+    cols.forEach((col, idx) => {
+      row[col.toLowerCase().trim()] = (cells[idx] ?? "").trim();
+    });
+    rows.push(row);
+  }
+  return rows;
+}
+
+function splitTableRow(line: string): string[] {
+  const trimmed = line.trim().replace(/^\|/, "").replace(/\|$/, "");
+  return trimmed.split("|").map((c) => c.trim());
+}
+
+export function stripBackticks(s: string): string {
+  return s.replace(/^`|`$/g, "").trim();
+}
+
+export function stripMarkdownLinks(s: string): string {
+  return s.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+}

--- a/src/lookups/archetype.ts
+++ b/src/lookups/archetype.ts
@@ -1,0 +1,198 @@
+import { codexPath } from "../lib/codex-root.js";
+import {
+  readMarkdown,
+  splitH2Sections,
+  parseFirstMarkdownTable,
+  stripMarkdownLinks,
+} from "../lib/markdown-parser.js";
+import type { Archetype, ArchetypeFull, ArchetypeSummary } from "../types.js";
+
+const ARCHETYPES_PATH = "core-lore/archetypes.md";
+
+const CANONICAL_NAMES: Archetype[] = [
+  "Freetekno",
+  "Milady",
+  "Acidhouse",
+  "Chicago/Detroit",
+];
+
+interface ArchetypeCache {
+  summaries: ArchetypeSummary[];
+  fullByName: Map<string, ArchetypeFull>;
+}
+
+let cache: ArchetypeCache | null = null;
+
+function loadArchetypes(): ArchetypeCache {
+  if (cache) return cache;
+
+  const md = readMarkdown(codexPath(ARCHETYPES_PATH));
+  const sections = splitH2Sections(md);
+
+  const overview = sections.find(
+    (s) => s.heading.toLowerCase() === "overview",
+  );
+  const indexRows = overview ? parseFirstMarkdownTable(overview.body) : [];
+  const indexBySig = new Map<string, ArchetypeSummary>();
+  for (const row of indexRows) {
+    const rawName = (row["archetype"] ?? "").replace(/\*\*/g, "").trim();
+    if (!rawName) continue;
+    const name = normalizeArchetypeAlias(rawName);
+    if (!name) continue;
+    const zodiac = (row["zodiac signs"] ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const season = row["season"] ?? "";
+    const era = row["era"] ?? "";
+    indexBySig.set(name.toLowerCase(), {
+      name,
+      era,
+      zodiac_signs: zodiac,
+      season,
+    });
+  }
+
+  const fullByName = new Map<string, ArchetypeFull>();
+  for (const canonical of CANONICAL_NAMES) {
+    const matchingHeading = sections.find(
+      (s) => normalizeHeading(s.heading) === normalizeHeading(canonical),
+    );
+    if (!matchingHeading) continue;
+
+    const summary = indexBySig.get(canonical.toLowerCase()) ?? {
+      name: canonical,
+      era: extractMetaLine(matchingHeading.body, "Time Period") ?? "",
+      zodiac_signs:
+        extractMetaLine(matchingHeading.body, "Zodiac Signs")?.split(",").map(
+          (s) => s.trim().replace(/\([^)]+\)/, "").trim(),
+        ) ?? [],
+      season: extractSeason(matchingHeading.body),
+    };
+
+    const locations = parseCSVMeta(matchingHeading.body, "Locations");
+    const figures = extractBulletNames(matchingHeading.body, "Key Figures");
+    const events = extractBulletNames(matchingHeading.body, "Key Events");
+    const drugs = extractDrugConnections(matchingHeading.body);
+    const ancestors = extractBulletNames(
+      matchingHeading.body,
+      "Ancestor Connections",
+    );
+    const fashion = parseCSVMeta(matchingHeading.body, "Fashion");
+
+    fullByName.set(canonical.toLowerCase(), {
+      ...summary,
+      locations,
+      figures,
+      events,
+      drugs,
+      ancestor_connections: ancestors,
+      fashion,
+      raw_section: matchingHeading.body.trim(),
+    });
+  }
+
+  const summaries = CANONICAL_NAMES.map(
+    (n) =>
+      indexBySig.get(n.toLowerCase()) ??
+      ({ name: n, era: "", zodiac_signs: [], season: "" } as ArchetypeSummary),
+  );
+
+  cache = { summaries, fullByName };
+  return cache;
+}
+
+function normalizeHeading(s: string): string {
+  return s.toLowerCase().replace(/\//g, "-").trim();
+}
+
+function extractMetaLine(body: string, label: string): string | undefined {
+  const re = new RegExp(`\\*\\*${label}:\\*\\*\\s*([^\\n]+)`, "i");
+  const m = body.match(re);
+  return m ? m[1].trim() : undefined;
+}
+
+function extractSeason(body: string): string {
+  const m = body.match(/\(([^)]*Summer|Winter|Spring|Fall|Autumn[^)]*)\)/i);
+  return m ? m[1].trim() : "";
+}
+
+function parseCSVMeta(body: string, label: string): string[] {
+  const line = extractMetaLine(body, label);
+  if (!line) return [];
+  return line
+    .split(",")
+    .map((s) => stripMarkdownLinks(s).replace(/[*_`]/g, "").trim())
+    .filter(Boolean);
+}
+
+function extractBulletNames(body: string, sectionHeading: string): string[] {
+  const re = new RegExp(
+    `\\*\\*${sectionHeading}:\\*\\*([\\s\\S]*?)(?=\\n###|\\n\\*\\*|$)`,
+    "i",
+  );
+  const m = body.match(re);
+  if (!m) return [];
+  return m[1]
+    .split("\n")
+    .filter((l) => l.trim().startsWith("-"))
+    .map((l) => l.replace(/^[-*]\s*/, "").trim())
+    .map((l) => l.replace(/^\*\*([^*]+)\*\*.*$/, "$1").trim())
+    .filter(Boolean);
+}
+
+function extractDrugConnections(body: string): {
+  modern: string[];
+  ancient: string[];
+} {
+  const drugSec = body.match(
+    /### Drug Connections\s*([\s\S]*?)(?=\n### |\n## |$)/,
+  );
+  if (!drugSec) return { modern: [], ancient: [] };
+  const rows = parseFirstMarkdownTable(drugSec[1]);
+  const first = rows[0] ?? {};
+  return {
+    modern: (first["modern"] ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+    ancient: (first["ancient"] ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+  };
+}
+
+export function lookupArchetype(name: string): ArchetypeFull | null {
+  const { fullByName } = loadArchetypes();
+  const canon = canonicalize(name);
+  if (!canon) return null;
+  return fullByName.get(canon.toLowerCase()) ?? null;
+}
+
+export function listArchetypes(): ArchetypeSummary[] {
+  return loadArchetypes().summaries.slice();
+}
+
+export function getArchetypeNames(): string[] {
+  return CANONICAL_NAMES.slice();
+}
+
+function canonicalize(input: string): Archetype | null {
+  return normalizeArchetypeAlias(input.trim());
+}
+
+function normalizeArchetypeAlias(input: string): Archetype | null {
+  const lower = input.toLowerCase().trim();
+  for (const n of CANONICAL_NAMES) {
+    if (n.toLowerCase() === lower) return n;
+  }
+  if (
+    lower === "chicago detroit" ||
+    lower === "chicago/detroit" ||
+    lower === "chicago" ||
+    lower === "detroit"
+  )
+    return "Chicago/Detroit";
+  return null;
+}

--- a/src/lookups/factor.ts
+++ b/src/lookups/factor.ts
@@ -1,0 +1,71 @@
+import { codexPath } from "../lib/codex-root.js";
+import {
+  readMarkdown,
+  splitH3Sections,
+} from "../lib/markdown-parser.js";
+import type { Archetype, Dimension, FactorLore } from "../types.js";
+
+const FACTOR_LORE_PATH = "core-lore/factor-lore.md";
+
+interface FactorCache {
+  byId: Map<string, FactorLore>;
+}
+
+let cache: FactorCache | null = null;
+
+function loadFactors(): FactorCache {
+  if (cache) return cache;
+
+  const md = readMarkdown(codexPath(FACTOR_LORE_PATH));
+  const sections = splitH3Sections(md);
+
+  const byId = new Map<string, FactorLore>();
+  for (const sec of sections) {
+    const id = sec.heading.trim();
+    if (!id.includes(":")) continue;
+
+    const dimMatch = sec.body.match(/-\s*\*\*dimension\*\*:\s*`([^`]+)`/i);
+    const archMatch = sec.body.match(/-\s*\*\*archetype\*\*:\s*([^\n]+)/i);
+    const statusMatch = sec.body.match(/-\s*\*\*status\*\*:\s*([^\n]+)/i);
+    const nameMatch = sec.body.match(/-\s*\*\*display_name\*\*:\s*([^\n]+)/i);
+    const loreMatch = sec.body.match(
+      /-\s*\*\*lore\*\*:\s*([\s\S]+?)(?=\n-\s*\*\*|$)/i,
+    );
+
+    const dim = (dimMatch?.[1] ?? "onchain").trim() as Dimension;
+    const archRaw = (archMatch?.[1] ?? "All").replace(/[*_`]/g, "").trim();
+    const status = (statusMatch?.[1] ?? "live").replace(/[*_`]/g, "").trim() as
+      | "live"
+      | "historic"
+      | "merged";
+    const displayName = (nameMatch?.[1] ?? id).replace(/[*_`]/g, "").trim();
+    const lore = (loreMatch?.[1] ?? "").trim();
+
+    byId.set(id, {
+      factor_id: id,
+      display_name: displayName,
+      dimension: dim,
+      archetype: archRaw === "All" ? "All" : (archRaw as Archetype),
+      lore,
+      codex_anchor: `core-lore/factor-lore.md#${id.replace(":", "")}`,
+      status,
+    });
+  }
+
+  cache = { byId };
+  return cache;
+}
+
+export function lookupFactor(factorId: string): FactorLore | null {
+  return loadFactors().byId.get(factorId) ?? null;
+}
+
+export function getFactorIds(): string[] {
+  return Array.from(loadFactors().byId.keys());
+}
+
+export function listLiveFactors(): FactorLore[] {
+  return Array.from(loadFactors().byId.values()).filter(
+    (f) => f.status === "live",
+  );
+}

--- a/src/lookups/grail.ts
+++ b/src/lookups/grail.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { codexPath } from "../lib/codex-root.js";
+import type { GrailEntry } from "../types.js";
+
+const GRAIL_JSONL = "_codex/data/grails.jsonl";
+
+interface GrailCache {
+  byId: Map<number, GrailEntry>;
+  bySlug: Map<string, GrailEntry>;
+  byName: Map<string, GrailEntry>;
+}
+
+let cache: GrailCache | null = null;
+
+function loadGrails(): GrailCache {
+  if (cache) return cache;
+
+  const raw = readFileSync(codexPath(GRAIL_JSONL), "utf8");
+  const byId = new Map<number, GrailEntry>();
+  const bySlug = new Map<string, GrailEntry>();
+  const byName = new Map<string, GrailEntry>();
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null) continue;
+    const e = parsed as GrailEntry & { slug?: string };
+    if (typeof e.id === "number") byId.set(e.id, e);
+    if (typeof e.slug === "string") bySlug.set(e.slug.toLowerCase(), e);
+    if (typeof e.name === "string") byName.set(e.name.toLowerCase(), e);
+  }
+
+  cache = { byId, bySlug, byName };
+  return cache;
+}
+
+export function lookupGrail(idOrSlugOrName: string | number): GrailEntry | null {
+  const c = loadGrails();
+  if (typeof idOrSlugOrName === "number") {
+    return c.byId.get(idOrSlugOrName) ?? null;
+  }
+  const trimmed = idOrSlugOrName.trim();
+  const asInt = Number(trimmed);
+  if (Number.isFinite(asInt) && c.byId.has(asInt)) return c.byId.get(asInt)!;
+  return (
+    c.bySlug.get(trimmed.toLowerCase()) ??
+    c.byName.get(trimmed.toLowerCase()) ??
+    null
+  );
+}
+
+export function getGrailNames(): string[] {
+  return Array.from(loadGrails().byName.keys());
+}

--- a/src/lookups/mibera.ts
+++ b/src/lookups/mibera.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { codexPath } from "../lib/codex-root.js";
+import type { MiberaEntry } from "../types.js";
+
+const MIBERA_JSONL = "_codex/data/miberas.jsonl";
+
+interface MiberaCache {
+  byId: Map<number, MiberaEntry>;
+}
+
+let cache: MiberaCache | null = null;
+
+function loadMiberas(): MiberaCache {
+  if (cache) return cache;
+
+  const raw = readFileSync(codexPath(MIBERA_JSONL), "utf8");
+  const byId = new Map<number, MiberaEntry>();
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null) continue;
+    const e = parsed as MiberaEntry;
+    if (typeof e.id === "number") byId.set(e.id, e);
+  }
+
+  cache = { byId };
+  return cache;
+}
+
+export function lookupMibera(id: number): MiberaEntry | null {
+  return loadMiberas().byId.get(id) ?? null;
+}
+
+export function getMiberaIds(): number[] {
+  return Array.from(loadMiberas().byId.keys());
+}
+
+export function getMiberaCount(): number {
+  return loadMiberas().byId.size;
+}

--- a/src/lookups/zone.ts
+++ b/src/lookups/zone.ts
@@ -1,0 +1,141 @@
+import { codexPath } from "../lib/codex-root.js";
+import {
+  readMarkdown,
+  splitH2Sections,
+  parseFirstMarkdownTable,
+  stripBackticks,
+  stripMarkdownLinks,
+} from "../lib/markdown-parser.js";
+import type { Archetype, ZoneFull, ZoneSummary } from "../types.js";
+
+const ZONES_PATH = "core-lore/festival-zones-vocabulary.md";
+
+const ZONE_EMOJI: Record<string, string> = {
+  stonehenge: "🪨",
+  "bear-cave": "🐻",
+  "el-dorado": "💎",
+  "owsley-lab": "🧪",
+  "the-warehouse": "🏭",
+};
+
+interface ZoneCache {
+  summaries: ZoneSummary[];
+  fullByslug: Map<string, ZoneFull>;
+}
+
+let cache: ZoneCache | null = null;
+
+function loadZones(): ZoneCache {
+  if (cache) return cache;
+
+  const md = readMarkdown(codexPath(ZONES_PATH));
+  const sections = splitH2Sections(md);
+
+  const indexSection = sections.find(
+    (s) => s.heading.toLowerCase() === "zone index",
+  );
+  const summaries: ZoneSummary[] = [];
+  if (indexSection) {
+    for (const row of parseFirstMarkdownTable(indexSection.body)) {
+      const slug = stripBackticks(row["slug"] ?? "");
+      const name = row["zone"] ?? "";
+      const archetypeRaw = stripMarkdownLinks(row["archetype"] ?? "")
+        .replace(/[*_]/g, "")
+        .trim();
+      const archetype: Archetype | "All" =
+        archetypeRaw === "" || archetypeRaw === "All"
+          ? "All"
+          : (archetypeRaw as Archetype);
+      if (!slug || !name) continue;
+      summaries.push({
+        slug,
+        name,
+        emoji: ZONE_EMOJI[slug],
+        archetype,
+      });
+    }
+  }
+
+  const fullByslug = new Map<string, ZoneFull>();
+  for (const summary of summaries) {
+    const heading = summary.slug;
+    const section =
+      sections.find((s) => s.heading.toLowerCase() === heading.toLowerCase()) ??
+      sections.find(
+        (s) => s.heading.toLowerCase() === summary.name.toLowerCase(),
+      );
+    if (!section) continue;
+
+    const lynchSection = extractSubsection(section.body, "Lynch Primitives");
+    const kanseiSection = extractSubsection(section.body, "KANSEI Tokens");
+    const lynch = lynchSection
+      ? tableAsRecord(lynchSection, "element", "vocabulary")
+      : undefined;
+    const kansei = kanseiSection
+      ? tableAsRecord(kanseiSection, "token", "value")
+      : undefined;
+    const essence = extractEssence(section.body);
+    const era = extractMetaLine(section.body, "Era resonance");
+
+    fullByslug.set(summary.slug, {
+      ...summary,
+      essence,
+      era_resonance: era,
+      lynch_primitives: lynch,
+      kansei_tokens: kansei,
+      raw_section: section.body.trim(),
+    });
+  }
+
+  cache = { summaries, fullByslug };
+  return cache;
+}
+
+function extractSubsection(body: string, heading: string): string | null {
+  const re = new RegExp(`### ${heading}([\\s\\S]*?)(?=\\n### |\\n## |$)`, "i");
+  const m = body.match(re);
+  return m ? m[1] : null;
+}
+
+function tableAsRecord(
+  body: string,
+  keyCol: string,
+  valCol: string,
+): Record<string, string> {
+  const rows = parseFirstMarkdownTable(body);
+  const out: Record<string, string> = {};
+  for (const row of rows) {
+    const key = (row[keyCol] ?? "").replace(/[*_`]/g, "").trim();
+    const val = (row[valCol] ?? "").replace(/[*_`]/g, "").trim();
+    if (key) out[key] = val;
+  }
+  return out;
+}
+
+function extractEssence(body: string): string {
+  const m = body.match(/\*\*Essence:\*\*\s*([^\n]+)/);
+  return m ? m[1].trim() : "";
+}
+
+function extractMetaLine(body: string, label: string): string | undefined {
+  const re = new RegExp(`\\*\\*${label}:\\*\\*\\s*([^\\n]+)`, "i");
+  const m = body.match(re);
+  return m ? m[1].trim() : undefined;
+}
+
+export function lookupZone(slug: string): ZoneFull | null {
+  const { fullByslug } = loadZones();
+  return fullByslug.get(slug.toLowerCase()) ?? null;
+}
+
+export function listZones(): ZoneSummary[] {
+  return loadZones().summaries.slice();
+}
+
+export function getZoneSlugs(): string[] {
+  return loadZones().summaries.map((z) => z.slug);
+}
+
+export function getZoneNames(): string[] {
+  return loadZones().summaries.map((z) => z.name);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,188 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { lookupZone, listZones } from "./lookups/zone.js";
+import { lookupArchetype, listArchetypes } from "./lookups/archetype.js";
+import { lookupFactor } from "./lookups/factor.js";
+import { lookupGrail } from "./lookups/grail.js";
+import { lookupMibera } from "./lookups/mibera.js";
+import { validateWorldElement } from "./validate.js";
+
+const VERSION = "1.1.0";
+const SERVER_NAME = "codex-mcp";
+
+export function createCodexMcpServer(): McpServer {
+  const server = new McpServer({ name: SERVER_NAME, version: VERSION });
+
+  server.tool(
+    "lookup_zone",
+    "Look up a festival zone by canonical slug. Returns name, emoji, archetype anchor, era, essence, Lynch primitives (paths/edges/districts/nodes/landmarks), KANSEI tokens (warmth/motion/shadow/easing/density/sound). Returns null if slug is not canonical.",
+    z.object({
+      slug: z
+        .string()
+        .min(1)
+        .describe("Zone slug, e.g. 'stonehenge', 'bear-cave', 'el-dorado'"),
+    }).shape,
+    async ({ slug }) => {
+      const zone = lookupZone(slug);
+      return {
+        content: [
+          {
+            type: "text",
+            text: zone
+              ? JSON.stringify(zone, null, 2)
+              : JSON.stringify({ error: "not_found", slug }),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "lookup_archetype",
+    "Look up one of the 4 canonical archetypes (Freetekno, Milady, Acidhouse, Chicago/Detroit). Returns era, zodiac signs, season, locations, key figures, key events, drug connections, ancestor connections, fashion. Returns null if name is not canonical.",
+    z.object({
+      name: z
+        .string()
+        .min(1)
+        .describe("Canonical archetype name, e.g. 'Freetekno', 'Milady'"),
+    }).shape,
+    async ({ name }) => {
+      const a = lookupArchetype(name);
+      return {
+        content: [
+          {
+            type: "text",
+            text: a ? JSON.stringify(a, null, 2) : JSON.stringify({ error: "not_found", name }),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "lookup_factor",
+    "Look up a score-mibera factor ID and return its codex lore (display name, dimension, archetype anchor, narrative lore, status). Cross-construct JOIN: score-mibera owns the factor ID surface, codex owns its lore. Returns null if factor ID is not in the codex factor-lore table.",
+    z.object({
+      factor_id: z
+        .string()
+        .min(1)
+        .describe(
+          "Factor ID emitted by score-mibera, e.g. 'nft:mibera', 'og:jani_keys', 'onchain:milady_burner'",
+        ),
+    }).shape,
+    async ({ factor_id }) => {
+      const f = lookupFactor(factor_id);
+      return {
+        content: [
+          {
+            type: "text",
+            text: f
+              ? JSON.stringify(f, null, 2)
+              : JSON.stringify({ error: "not_found", factor_id }),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "lookup_grail",
+    "Look up a 1/1 grail by token ID, slug, or display name. Returns id, name, category (element/luminary/concept/zodiac/planet/ancestor/primordial/special/community), description, status. Returns null if not found.",
+    z.object({
+      query: z
+        .string()
+        .min(1)
+        .describe(
+          "Token ID (number as string), slug ('buddhist'), or display name ('Scorpio')",
+        ),
+    }).shape,
+    async ({ query }) => {
+      const g = lookupGrail(query);
+      return {
+        content: [
+          {
+            type: "text",
+            text: g ? JSON.stringify(g, null, 2) : JSON.stringify({ error: "not_found", query }),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "lookup_mibera",
+    "Look up a single Mibera by ID (1-10000). Returns canonical traits: archetype, ancestor, time_period, birthday, birth_coordinates, sun/moon/ascending sign, element, swag_rank/score, full visual trait set (background, body, hair, eyes, eyebrows, mouth, shirt, hat, glasses, mask, earrings, face_accessory, tattoo, item), drug, and parcel ID.",
+    z.object({
+      id: z
+        .number()
+        .int()
+        .min(1)
+        .max(10000)
+        .describe("Mibera ID, 1-10000"),
+    }).shape,
+    async ({ id }) => {
+      const m = lookupMibera(id);
+      return {
+        content: [
+          {
+            type: "text",
+            text: m ? JSON.stringify(m, null, 2) : JSON.stringify({ error: "not_found", id }),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "list_zones",
+    "List all canonical festival zones. Returns array of {slug, name, emoji, archetype}. Use to discover available zones before calling lookup_zone.",
+    z.object({}).shape,
+    async () => ({
+      content: [
+        { type: "text", text: JSON.stringify(listZones(), null, 2) },
+      ],
+    }),
+  );
+
+  server.tool(
+    "list_archetypes",
+    "List all 4 canonical archetypes. Returns array of {name, era, zodiac_signs, season}. Use to discover canonical archetype names before calling lookup_archetype or to validate archetype claims in narrative output.",
+    z.object({}).shape,
+    async () => ({
+      content: [
+        { type: "text", text: JSON.stringify(listArchetypes(), null, 2) },
+      ],
+    }),
+  );
+
+  server.tool(
+    "validate_world_element",
+    "Validate that a world-element value is canonical. Returns {canonical: bool, suggested?: string, distance?: number}. If the value is not canonical, fuzzy-matches against the canonical set and suggests the closest match (Levenshtein distance, type-tuned threshold). Unmatched-but-Mibera-relevant queries are appended to grimoires/codex-mcp/coverage-gaps.jsonl for periodic curator review (per RFC #53 C6).",
+    z.object({
+      type: z
+        .enum(["zone", "archetype", "factor", "grail", "mibera"])
+        .describe("World-element type to validate against"),
+      value: z.string().min(1).describe("Value to validate"),
+      consumer_hint: z
+        .string()
+        .optional()
+        .describe(
+          "Optional consumer identifier for the coverage-gap log (e.g. 'ruggy-v06', 'satoshi-v07')",
+        ),
+    }).shape,
+    async ({ type, value, consumer_hint }) => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            validateWorldElement(type, value, consumer_hint),
+            null,
+            2,
+          ),
+        },
+      ],
+    }),
+  );
+
+  return server;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,113 @@
+export type Archetype = "Freetekno" | "Milady" | "Acidhouse" | "Chicago/Detroit";
+
+export type Dimension = "og" | "nft" | "onchain" | "tl" | "irl";
+
+export interface ZoneSummary {
+  slug: string;
+  name: string;
+  emoji?: string;
+  archetype: Archetype | "All";
+}
+
+export interface ZoneFull extends ZoneSummary {
+  essence: string;
+  era_resonance?: string;
+  lynch_primitives?: Record<string, string>;
+  kansei_tokens?: Record<string, string>;
+  raw_section?: string;
+}
+
+export interface ArchetypeSummary {
+  name: Archetype;
+  era: string;
+  zodiac_signs: string[];
+  season: string;
+}
+
+export interface ArchetypeFull extends ArchetypeSummary {
+  locations: string[];
+  figures: string[];
+  events: string[];
+  drugs: { modern: string[]; ancient: string[] };
+  ancestor_connections: string[];
+  fashion: string[];
+  raw_section?: string;
+}
+
+export interface FactorLore {
+  factor_id: string;
+  display_name: string;
+  dimension: Dimension;
+  archetype?: Archetype | "All";
+  lore: string;
+  codex_anchor?: string;
+  status: "live" | "historic" | "merged";
+}
+
+export interface MiberaEntry {
+  id: number;
+  archetype: Archetype;
+  ancestor: string;
+  time_period: string;
+  birthday: string;
+  birth_coordinates: string;
+  sun_sign: string;
+  moon_sign: string;
+  ascending_sign: string;
+  element: "Earth" | "Fire" | "Water" | "Air";
+  swag_rank: "Sss" | "Ss" | "S" | "A" | "B" | "C" | "D" | "F";
+  swag_score: number;
+  background: string;
+  body: string;
+  hair: string | null;
+  eyes: string;
+  eyebrows: string;
+  mouth: string;
+  shirt: string | null;
+  hat: string | null;
+  glasses: string | null;
+  mask: string | null;
+  earrings: string | null;
+  face_accessory: string | null;
+  tattoo: string | null;
+  item: string | null;
+  drug: string;
+  parcel?: number;
+}
+
+export interface GrailEntry {
+  id?: number;
+  name: string;
+  type: "grail";
+  category:
+    | "element"
+    | "luminary"
+    | "concept"
+    | "zodiac"
+    | "planet"
+    | "ancestor"
+    | "primordial"
+    | "special"
+    | "community";
+  description?: string;
+  commissioned_for?: string;
+  status?: "on-chain" | "pending";
+}
+
+export type WorldElementType = "zone" | "archetype" | "factor" | "grail" | "mibera";
+
+export interface ValidateResult {
+  canonical: boolean;
+  suggested?: string;
+  distance?: number;
+  type: WorldElementType;
+}
+
+export interface CoverageGap {
+  ts: string;
+  type: WorldElementType;
+  value: string;
+  suggested: string | null;
+  distance: number | null;
+  consumer_hint?: string;
+}

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,76 @@
+import { suggestClosest } from "./lib/levenshtein.js";
+import { logCoverageGap } from "./coverage-gaps.js";
+import { getZoneSlugs, getZoneNames } from "./lookups/zone.js";
+import { getArchetypeNames } from "./lookups/archetype.js";
+import { getFactorIds } from "./lookups/factor.js";
+import { getGrailNames } from "./lookups/grail.js";
+import { getMiberaIds } from "./lookups/mibera.js";
+import type { ValidateResult, WorldElementType } from "./types.js";
+
+const FUZZY_THRESHOLD: Record<WorldElementType, number> = {
+  zone: 3,
+  archetype: 3,
+  factor: 4,
+  grail: 4,
+  mibera: 0,
+};
+
+export function validateWorldElement(
+  type: WorldElementType,
+  value: string,
+  consumerHint?: string,
+): ValidateResult {
+  const trimmed = value.trim();
+
+  switch (type) {
+    case "zone": {
+      const canonical = getZoneSlugs().concat(getZoneNames());
+      return decide(type, trimmed, canonical, consumerHint);
+    }
+    case "archetype": {
+      return decide(type, trimmed, getArchetypeNames(), consumerHint);
+    }
+    case "factor": {
+      return decide(type, trimmed, getFactorIds(), consumerHint);
+    }
+    case "grail": {
+      return decide(type, trimmed, getGrailNames(), consumerHint);
+    }
+    case "mibera": {
+      const id = Number(trimmed);
+      if (Number.isInteger(id) && getMiberaIds().includes(id)) {
+        return { canonical: true, type };
+      }
+      logCoverageGap(type, trimmed, null, null, consumerHint);
+      return { canonical: false, type };
+    }
+  }
+}
+
+function decide(
+  type: WorldElementType,
+  value: string,
+  candidates: readonly string[],
+  consumerHint?: string,
+): ValidateResult {
+  const exactHit = candidates.find(
+    (c) => c.toLowerCase() === value.toLowerCase(),
+  );
+  if (exactHit) return { canonical: true, type };
+
+  const threshold = FUZZY_THRESHOLD[type];
+  const suggestion = suggestClosest(value, candidates, threshold);
+
+  if (suggestion) {
+    logCoverageGap(type, value, suggestion.match, suggestion.distance, consumerHint);
+    return {
+      canonical: false,
+      suggested: suggestion.match,
+      distance: suggestion.distance,
+      type,
+    };
+  }
+
+  logCoverageGap(type, value, null, null, consumerHint);
+  return { canonical: false, type };
+}

--- a/tests-smoke/codex-smoke.ts
+++ b/tests-smoke/codex-smoke.ts
@@ -1,0 +1,76 @@
+import { lookupZone, listZones } from "../src/lookups/zone.js";
+import { lookupArchetype, listArchetypes } from "../src/lookups/archetype.js";
+import { lookupFactor, getFactorIds } from "../src/lookups/factor.js";
+import { lookupGrail } from "../src/lookups/grail.js";
+import { lookupMibera } from "../src/lookups/mibera.js";
+import { validateWorldElement } from "../src/validate.js";
+
+console.log("=== list_zones ===");
+console.log(JSON.stringify(listZones(), null, 2));
+
+console.log("\n=== lookup_zone(stonehenge) ===");
+const z = lookupZone("stonehenge");
+console.log(JSON.stringify({
+  name: z?.name,
+  archetype: z?.archetype,
+  emoji: z?.emoji,
+  essence: z?.essence,
+  era: z?.era_resonance,
+  has_lynch: !!z?.lynch_primitives,
+  has_kansei: !!z?.kansei_tokens,
+  lynch_keys: z?.lynch_primitives ? Object.keys(z.lynch_primitives) : [],
+}, null, 2));
+
+console.log("\n=== list_archetypes ===");
+console.log(JSON.stringify(listArchetypes(), null, 2));
+
+console.log("\n=== lookup_archetype(Freetekno) ===");
+const a = lookupArchetype("Freetekno");
+console.log(JSON.stringify({
+  name: a?.name,
+  era: a?.era,
+  zodiac: a?.zodiac_signs,
+  season: a?.season,
+  locations_count: a?.locations.length,
+  figures_count: a?.figures.length,
+  events_count: a?.events.length,
+  drugs: a?.drugs,
+  ancestor_count: a?.ancestor_connections.length,
+}, null, 2));
+
+console.log("\n=== getFactorIds (count + sample) ===");
+const fids = getFactorIds();
+console.log("count:", fids.length, "sample:", fids.slice(0, 5));
+
+console.log("\n=== lookup_factor(nft:mibera) ===");
+const f = lookupFactor("nft:mibera");
+console.log(JSON.stringify(f, null, 2));
+
+console.log("\n=== lookup_factor(nft:mibera_quality) ===");
+const fh = lookupFactor("nft:mibera_quality");
+console.log(JSON.stringify({ id: fh?.factor_id, status: fh?.status, archetype: fh?.archetype }, null, 2));
+
+console.log("\n=== lookup_grail(buddhist) ===");
+console.log(JSON.stringify(lookupGrail("buddhist"), null, 2));
+
+console.log("\n=== lookup_mibera(1) ===");
+const m = lookupMibera(1);
+console.log(JSON.stringify({
+  id: m?.id,
+  archetype: m?.archetype,
+  ancestor: m?.ancestor,
+  drug: m?.drug,
+  swag: m?.swag_rank,
+}, null, 2));
+
+console.log("\n=== validate_world_element ===");
+console.log("zone(bear-cave):", JSON.stringify(validateWorldElement("zone", "bear-cave")));
+console.log("zone(bearcave):", JSON.stringify(validateWorldElement("zone", "bearcave")));
+console.log("archetype(Freetekno):", JSON.stringify(validateWorldElement("archetype", "Freetekno")));
+console.log("archetype(Freetech):", JSON.stringify(validateWorldElement("archetype", "Freetech")));
+console.log("archetype(Atlantis):", JSON.stringify(validateWorldElement("archetype", "Atlantis")));
+console.log("factor(nft:mibera):", JSON.stringify(validateWorldElement("factor", "nft:mibera")));
+console.log("mibera(1):", JSON.stringify(validateWorldElement("mibera", "1")));
+console.log("mibera(99999):", JSON.stringify(validateWorldElement("mibera", "99999")));
+
+console.log("\n=== smoke test passed ===");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true,
+    "allowImportingTsExtensions": false,
+    "noEmitOnError": true
+  },
+  "include": ["bin/**/*.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests/**", "skills/**"]
+}


### PR DESCRIPTION
Closes #53.

Adopts the v1 design Gumi locked in [#53 (2026-04-29)](https://github.com/0xHoneyJar/construct-mibera-codex/issues/53#issuecomment-).

## Verdict reconciliation

**Doctrines (locked):**
- ✅ **D1** codex-mcp parallel to score-mcp
- ✅ **D2** anti-hallucination + operator-side maintenance reduction (co-motivation)
- ✅ **D3** codex SoT, MCP read-only

**Shaped cards:**
- ✅ **C1** ship 7 + `lookup_mibera` = **8 tools**
- ✅ **C1.Q1.2** factor mapping lives in codex → `core-lore/factor-lore.md` (operator-seeded; **🪶 28 entries marked `TODO (Gumi)` for curation**)
- ✅ **C2** hybrid response — JSON now, optional markdown for rich lore deferred until factor-lore entries are curated
- ✅ **C3** `validate_world_element` returns `suggested-closest` (Levenshtein, type-tuned threshold)
- ✅ **C4** rolling latest, no semver tags
- ✅ **C5** graceful degradation (consumer-side fallback pattern; MCP logs file-not-found cleanly)

**Open card (added by Gumi):**
- ✅ **C6** **coverage gap log** at v1 → `grimoires/codex-mcp/coverage-gaps.jsonl`. Unmatched-but-Mibera-relevant queries appended with timestamp + suggested-closest. Gitignored — local curator-review surface.

## v1 tool surface

| Tool | Returns |
|---|---|
| `lookup_zone(slug)` | name, emoji, archetype, era, essence, Lynch primitives, KANSEI tokens |
| `lookup_archetype(name)` | era, zodiac, season, locations, figures, events, drugs, ancestors, fashion |
| `lookup_factor(factor_id)` | cross-construct JOIN with score-mibera (display name, dimension, archetype, lore, status) |
| `lookup_grail(query)` | by ID/slug/name (name, category, description) |
| `lookup_mibera(id)` | full canonical trait set (1-10000) |
| `list_zones()` / `list_archetypes()` | summaries |
| `validate_world_element(type, value)` | canonical bool + suggested-closest + coverage-gap log |

## Anti-hallucination tier model (declared in `beacon.yaml.mcp.tiers`)

- **🔒 HARD** — substrate enforces, LLM cannot escape (zone slug/emoji/archetype, archetype canonical names, factor IDs, mibera IDs, grail IDs)
- **🪶 SOFT** — MCP provides reference, LLM has creative license over composition (zone essence, KANSEI texture, archetype figures/events/fashion, factor lore)
- **🌀 LLM-OWNED** — no MCP involvement (narrator voice, activity-class words, closing observations)

## How to test

```bash
git checkout feat/codex-mcp-v1
pnpm install
pnpm mcp                                           # stdio MCP server
npx tsx tests-smoke/codex-smoke.ts                 # all 8 tools + fuzzy validate + coverage log
```

Add to Claude Code `claude_desktop_config.json` or `.claude/settings.json`:

```json
{
  \"mcpServers\": {
    \"codex\": {
      \"command\": \"pnpm\",
      \"args\": [\"--prefix\", \"/path/to/construct-mibera-codex\", \"mcp\"]
    }
  }
}
```

## Source-of-truth files

| Tool | Reads from |
|---|---|
| `lookup_zone` / `list_zones` | `core-lore/festival-zones-vocabulary.md` |
| `lookup_archetype` / `list_archetypes` | `core-lore/archetypes.md` |
| `lookup_factor` | `core-lore/factor-lore.md` *(NEW — Gumi to curate)* |
| `lookup_grail` | `_codex/data/grails.jsonl` |
| `lookup_mibera` | `_codex/data/miberas.jsonl` |

## Outstanding work for Gumi

1. **Curate `core-lore/factor-lore.md`** — 28 factors seeded with `TODO (Gumi)` markers. Each `## og:* / nft:* / onchain:*` h3 has `dimension`, `archetype`, `status`, `display_name`, `lore`. The lore copy is operator-stub for now — replace with curator voice.
2. **Review the tier model** in `beacon.yaml` — push back if anything should move between HARD/SOFT/LLM-OWNED.
3. **Coverage gap log review cadence** — periodic check of `grimoires/codex-mcp/coverage-gaps.jsonl` (gitignored). Surface gaps tells the curation roadmap.

## Deferred to v2

- `lookup_ancestor` (33 ancestors in `core-lore/ancestors/`)
- `lookup_trait` (1,337 traits)
- `lookup_drug` (78 in `traits/overlays/molecules/`)
- `lookup_tarot` (78 in `core-lore/tarot-cards/`)
- write-events / observation logging
- Path B (Streamable HTTP transport + Dockerfile) — when production bot deploy needs remote MCP
- Path C (constructs.network registry-gateway hosting) — future

## Doctrine references

- **`constructs-mcp-shape`** — four-op core (lookup × list × validate × describe), UNIX self-description, JOIN-bridge pattern, HARD/SOFT/LLM-OWNED tier model
- **`constructs-mcp-deployment-topology`** — three host paths; this PR is Path A (stdio)
- **`mcp-wraps-cli-pattern`** — every canonical CLI gets an MCP mirror
- **construct-beacon v2.1.0** — `/beacon-mcp` skill is the codegen path; this PR is the first adoption

## Files

```
beacon.yaml                       MCP block declaration (shape, paths, tools, tiers)
bin/mcp.ts                         stdio entry-point
src/server.ts                      McpServer factory (8 tools)
src/lookups/{zone,archetype,factor,grail,mibera}.ts   parsers + lookup logic
src/lists.ts                       (composed inside lookups; list_zones / list_archetypes)
src/validate.ts                    fuzzy validate + coverage-gap dispatch
src/coverage-gaps.ts               JSONL append-only logger
src/lib/codex-root.ts              repo-root locator
src/lib/markdown-parser.ts         h2/h3 sectioning + table parsing
src/lib/levenshtein.ts             distance + suggest-closest
src/types.ts                       TS types for all entities + validate result
core-lore/factor-lore.md           NEW · operator-seeded · 28 factors · Gumi to curate
package.json                       NEW · @modelcontextprotocol/sdk + zod + gray-matter
tsconfig.json                      NEW
.gitignore                         + dist/, coverage-gaps log, .env
README.md                          + § codex-mcp section
construct.yaml                     1.0.0 → 1.1.0 + mcp block
tests-smoke/codex-smoke.ts         smoke test for parser + lookup + validate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)