### PR TITLE
feat(cli): codex CLI surface (bucket-1) · closes #62

### DIFF
--- a/beacon.yaml
+++ b/beacon.yaml
@@ -1,6 +1,29 @@
-# Beacon MCP declaration for construct-mibera-codex
-# Generated following the constructs-mcp-shape doctrine
-# (see vault: constructs-mcp-shape, constructs-mcp-deployment-topology)
+# Beacon MCP + CLI declaration for construct-mibera-codex
+# Generated following the constructs-mcp-shape + construct-surface-decision-tree doctrines
+# (see vault: constructs-mcp-shape, constructs-mcp-deployment-topology, construct-surface-decision-tree)
+
+# Bucket-1 surface (per `~/vault/wiki/concepts/construct-surface-decision-tree.md`):
+# stateless data-shaped construct with both human + agent consumers — CLI primary,
+# MCP wraps. Subcommands mirror MCP tools 1:1 (parallel verbs, cross-construct legibility).
+
+cli:
+  binary: codex
+  entry: bin/codex.ts
+  install: npx @0xhoneyjar/construct-mibera-codex   # or pack-local via Loa
+  subcommands:
+    - codex lookup zone <slug>
+    - codex lookup archetype <name>
+    - codex lookup factor <factor-id>
+    - codex lookup grail <id|slug|name> [--field=<name>]
+    - codex lookup mibera <token-id>
+    - codex list zones
+    - codex list archetypes
+    - codex validate <type> <value> [--consumer-hint=<id>]
+  output: stdout JSON (compact JSON via --field=<name> for raw text)
+  exit_codes:
+    0: success
+    1: not_found
+    2: usage_error
 
 mcp:
   shape: data

--- a/bin/codex.ts
+++ b/bin/codex.ts
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+/**
+ * codex — Mibera Codex CLI.
+ *
+ * The bucket-1 CLI half (per `~/vault/wiki/concepts/construct-surface-decision-tree.md`).
+ * Subcommands mirror the 8 MCP tools verbatim: lookup_X / list_X / validate_*
+ * become `codex lookup X` / `codex list X` / `codex validate <type> <value>`.
+ * Cross-construct legibility is the integration contract — same vocabulary
+ * across CLI and MCP, no synonym drift.
+ *
+ * Output convention: stdout = JSON (pretty unless --field), stderr = log.
+ * Exit codes: 0 = success, 1 = not_found, 2 = usage error.
+ *
+ * --field=<name> extracts a single field from object lookups; for string
+ * fields, raw text is written (pipeable into shell). For non-string fields,
+ * JSON-stringified output. Mirrors `jq -r` semantics.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { lookupZone, listZones } from "../src/lookups/zone.js";
+import {
+  lookupArchetype,
+  listArchetypes,
+} from "../src/lookups/archetype.js";
+import { lookupFactor } from "../src/lookups/factor.js";
+import { lookupGrail } from "../src/lookups/grail.js";
+import { lookupMibera } from "../src/lookups/mibera.js";
+import { validateWorldElement } from "../src/validate.js";
+import type { WorldElementType } from "../src/types.js";
+
+// ────── argv parsing ──────
+
+interface ParsedArgs {
+  positional: string[];
+  flags: Record<string, string | boolean>;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const positional: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+  for (const arg of argv) {
+    if (arg.startsWith("--")) {
+      const eq = arg.indexOf("=");
+      if (eq >= 0) {
+        flags[arg.slice(2, eq)] = arg.slice(eq + 1);
+      } else {
+        flags[arg.slice(2)] = true;
+      }
+    } else if (arg.startsWith("-") && arg.length > 1) {
+      flags[arg.slice(1)] = true;
+    } else {
+      positional.push(arg);
+    }
+  }
+  return { positional, flags };
+}
+
+// ────── output helpers ──────
+
+function emit(value: unknown, field?: string): never {
+  if (value === null || value === undefined) {
+    process.stderr.write("error: not_found\n");
+    process.exit(1);
+  }
+  if (field) {
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      Array.isArray(value) ||
+      !(field in value)
+    ) {
+      process.stderr.write(`error: field "${field}" not present in result\n`);
+      process.exit(1);
+    }
+    const fv = (value as Record<string, unknown>)[field];
+    if (fv === null || fv === undefined) {
+      process.stderr.write(`error: field "${field}" is null\n`);
+      process.exit(1);
+    }
+    if (typeof fv === "string") {
+      process.stdout.write(fv + "\n");
+    } else {
+      process.stdout.write(JSON.stringify(fv) + "\n");
+    }
+    process.exit(0);
+  }
+  process.stdout.write(JSON.stringify(value, null, 2) + "\n");
+  process.exit(0);
+}
+
+function fail(message: string, code: number = 2): never {
+  process.stderr.write(`error: ${message}\n`);
+  process.exit(code);
+}
+
+// ────── version ──────
+
+function getVersion(): string {
+  // Walk up from the binary's directory looking for package.json. Handles
+  // both production (`dist/bin/codex.js` → ../../package.json) and dev via
+  // tsx (`bin/codex.ts` → ../package.json).
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 5; i++) {
+    try {
+      const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as {
+        version?: string;
+      };
+      if (pkg.version) return pkg.version;
+    } catch {
+      // not here; walk up
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return "unknown";
+}
+
+// ────── help text (--help is the schema) ──────
+
+const ROOT_HELP = `codex — Mibera Codex CLI
+
+Anti-hallucination lookup for Mibera lore: zones, archetypes, factors, grails,
+miberas. Subcommands mirror the codex-mcp tool surface 1:1 — same vocabulary,
+two transports.
+
+Usage:
+  codex <command> [args] [flags]
+
+Commands:
+  lookup <noun> <query>    Look up a single entity (zone / archetype / factor / grail / mibera)
+  list <noun>              List canonical entities (zones / archetypes)
+  validate <type> <value>  Validate a value against the canonical set (suggests closest)
+
+Global flags:
+  --help, -h               Show this message
+  --version, -v            Print version
+  --field=<name>           Extract a single field from lookup results (raw output, pipeable)
+
+Examples:
+  codex lookup grail black-hole --field=image
+  codex lookup zone bear-cave
+  codex lookup archetype Freetekno
+  codex lookup factor nft:mibera
+  codex lookup mibera 4488
+  codex list zones
+  codex validate archetype Freetech
+
+Doctrine: ~/vault/wiki/concepts/construct-surface-decision-tree.md
+MCP equivalent: codex-mcp (same tool surface, same data, agent-native transport)`;
+
+const LOOKUP_HELP = `codex lookup — single-entity lookup
+
+Usage:
+  codex lookup zone <slug>             Look up a festival zone (e.g. stonehenge, bear-cave)
+  codex lookup archetype <name>        Look up an archetype (Freetekno, Milady, Acidhouse, Chicago/Detroit)
+  codex lookup factor <factor-id>      Look up a score-mibera factor and return its codex lore
+  codex lookup grail <id|slug|name>    Look up a 1/1 grail (token ID, slug, or display name)
+  codex lookup mibera <token-id>       Look up a single Mibera by token ID (1-10000)
+
+Flags:
+  --field=<name>                       Extract a single field from the result (raw output)
+
+Exits 1 if the entity is not found.`;
+
+const LIST_HELP = `codex list — enumerate canonical entities
+
+Usage:
+  codex list zones                     List all canonical festival zones
+  codex list archetypes                List all 4 canonical archetypes`;
+
+const VALIDATE_HELP = `codex validate — check a value against the canonical set
+
+Usage:
+  codex validate <type> <value> [--consumer-hint=<id>]
+
+Types: zone, archetype, factor, grail, mibera
+
+Returns {canonical: bool, suggested?: string, distance?: number, type}.
+Unmatched but Mibera-relevant queries are appended to the coverage-gap log
+for periodic curator review (per RFC #53 C6).`;
+
+// ────── command handlers ──────
+
+function handleLookup(rest: string[], flags: Record<string, string | boolean>): never {
+  if (flags.help || flags.h) {
+    process.stdout.write(LOOKUP_HELP + "\n");
+    process.exit(0);
+  }
+  const [noun, query, ...extra] = rest;
+  if (!noun) fail("missing noun. usage: codex lookup <zone|archetype|factor|grail|mibera> <query>");
+  if (extra.length > 0) fail(`unexpected positional argument(s): ${extra.join(" ")}`);
+  const field = typeof flags.field === "string" ? flags.field : undefined;
+
+  switch (noun) {
+    case "zone":
+      if (!query) fail("missing slug. usage: codex lookup zone <slug>");
+      emit(lookupZone(query), field);
+      break;
+    case "archetype":
+      if (!query) fail("missing name. usage: codex lookup archetype <name>");
+      emit(lookupArchetype(query), field);
+      break;
+    case "factor":
+      if (!query) fail("missing factor-id. usage: codex lookup factor <factor-id>");
+      emit(lookupFactor(query), field);
+      break;
+    case "grail":
+      if (!query) fail("missing query. usage: codex lookup grail <id|slug|name>");
+      emit(lookupGrail(query), field);
+      break;
+    case "mibera": {
+      if (!query) fail("missing token-id. usage: codex lookup mibera <token-id>");
+      const id = Number(query);
+      if (!Number.isFinite(id) || !Number.isInteger(id) || id < 1 || id > 10000) {
+        fail(`invalid token-id "${query}" — must be integer 1-10000`);
+      }
+      emit(lookupMibera(id), field);
+      break;
+    }
+    default:
+      fail(`unknown noun "${noun}". expected: zone, archetype, factor, grail, mibera`);
+  }
+}
+
+function handleList(rest: string[], flags: Record<string, string | boolean>): never {
+  if (flags.help || flags.h) {
+    process.stdout.write(LIST_HELP + "\n");
+    process.exit(0);
+  }
+  const [noun, ...extra] = rest;
+  if (!noun) fail("missing noun. usage: codex list <zones|archetypes>");
+  if (extra.length > 0) fail(`unexpected positional argument(s): ${extra.join(" ")}`);
+
+  switch (noun) {
+    case "zones":
+      emit(listZones());
+      break;
+    case "archetypes":
+      emit(listArchetypes());
+      break;
+    default:
+      fail(`unknown noun "${noun}". expected: zones, archetypes`);
+  }
+}
+
+function handleValidate(rest: string[], flags: Record<string, string | boolean>): never {
+  if (flags.help || flags.h) {
+    process.stdout.write(VALIDATE_HELP + "\n");
+    process.exit(0);
+  }
+  const [type, ...valueParts] = rest;
+  if (!type) fail("missing type. usage: codex validate <type> <value>");
+  const value = valueParts.join(" ");
+  if (!value) fail("missing value. usage: codex validate <type> <value>");
+
+  const validTypes: WorldElementType[] = ["zone", "archetype", "factor", "grail", "mibera"];
+  if (!validTypes.includes(type as WorldElementType)) {
+    fail(`unknown type "${type}". expected: ${validTypes.join(", ")}`);
+  }
+  const consumerHint =
+    typeof flags["consumer-hint"] === "string" ? (flags["consumer-hint"] as string) : undefined;
+  emit(validateWorldElement(type as WorldElementType, value, consumerHint));
+}
+
+// ────── main ──────
+
+function main(): never {
+  const { positional, flags } = parseArgs(process.argv.slice(2));
+
+  if (flags.version || flags.v) {
+    process.stdout.write(getVersion() + "\n");
+    process.exit(0);
+  }
+  if (flags.help || flags.h || positional.length === 0) {
+    process.stdout.write(ROOT_HELP + "\n");
+    process.exit(positional.length === 0 ? 0 : 0);
+  }
+
+  const [verb, ...rest] = positional;
+  switch (verb) {
+    case "lookup":
+      handleLookup(rest, flags);
+      break;
+    case "list":
+      handleList(rest, flags);
+      break;
+    case "validate":
+      handleValidate(rest, flags);
+      break;
+    default:
+      fail(`unknown command "${verb}". expected: lookup, list, validate. try \`codex --help\``);
+  }
+}
+
+main();

--- a/bin/codex.ts
+++ b/bin/codex.ts
@@ -8,12 +8,11 @@
  * Cross-construct legibility is the integration contract — same vocabulary
  * across CLI and MCP, no synonym drift.
  *
- * Output convention: stdout = JSON (pretty unless --field), stderr = log.
+ * Output convention:
+ *   - default: stdout = pretty JSON (2-space indent), stderr = log.
+ *   - --field=<name>: stdout = raw text for string fields, compact JSON for
+ *     non-string fields. Mirrors `jq -r` semantics; pipeable into shell.
  * Exit codes: 0 = success, 1 = not_found, 2 = usage error.
- *
- * --field=<name> extracts a single field from object lookups; for string
- * fields, raw text is written (pipeable into shell). For non-string fields,
- * JSON-stringified output. Mirrors `jq -r` semantics.
  */
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -275,7 +274,7 @@ function main(): never {
   }
   if (flags.help || flags.h || positional.length === 0) {
     process.stdout.write(ROOT_HELP + "\n");
-    process.exit(positional.length === 0 ? 0 : 0);
+    process.exit(0);
   }
 
   const [verb, ...rest] = positional;

--- a/construct.yaml
+++ b/construct.yaml
@@ -28,6 +28,20 @@ commands:
     path: commands/codex.md
     description: "Query the Mibera knowledge base"
 
+cli:
+  binary: codex
+  entry: bin/codex.ts
+  declaration: beacon.yaml
+  subcommands:
+    - lookup zone <slug>
+    - lookup archetype <name>
+    - lookup factor <factor-id>
+    - lookup grail <id|slug|name>
+    - lookup mibera <token-id>
+    - list zones
+    - list archetypes
+    - validate <type> <value>
+
 mcp:
   shape: data
   paths:

--- a/grails/README.md
+++ b/grails/README.md
@@ -5,6 +5,43 @@
 
 ---
 
+## Image URL convention
+
+Each grail is hosted at:
+
+```
+https://assets.0xhoneyjar.xyz/Mibera/grails/{slug}.png
+```
+
+where `{slug}` is the canonical slug field from `_codex/data/grails.jsonl` —
+**lowercase ASCII with spaces replaced by hyphens**:
+
+| name | slug | url |
+|---|---|---|
+| Black Hole | `black-hole` | `…/grails/black-hole.png` |
+| Native American | `native-american` | `…/grails/native-american.png` |
+| Satoshi as Hermes | `satoshi-as-hermes` | `…/grails/satoshi-as-hermes.png` |
+| Scorpio | `scorpio` | `…/grails/scorpio.png` |
+
+The `image` field is materialized in `_codex/data/grails.jsonl` for all 43
+entries (alongside `original_image` pointing at the legacy irys URL and an
+NFT-metadata `attributes` array). Programmatic consumers should read `image`
+from there rather than re-deriving from the slug. The convention above is the
+authority that survives if the URL pattern ever changes.
+
+Programmatic access:
+
+- **CLI** — `codex lookup grail black-hole --field=image`
+- **MCP** — `lookup_grail({query: "black-hole"})` → the `image` field is in the response
+- **Raw** — read the relevant line from `_codex/data/grails.jsonl`
+
+The empirical convention was discovered via [issue #62](https://github.com/0xHoneyJar/construct-mibera-codex/issues/62)
+(Adeitasuna, 2026-04-30) — 40 of 42 grails resolved on first guess; multi-word
+names (`Black Hole`, `Native American`) required ~14 HEAD probes each before
+the lowercase-hyphenated form was identified. This document closes that gap.
+
+---
+
 ## Elements (4)
 
 - [Fire](fire.md) · #6458

--- a/grimoires/loa/NOTES.md
+++ b/grimoires/loa/NOTES.md
@@ -65,6 +65,26 @@
 
 ## Decisions
 
+### Session 07 — bucket-1 CLI surface (2026-05-02)
+
+Session 07 ships `bin/codex.ts` as the bucket-1 CLI half (per `~/vault/wiki/concepts/construct-surface-decision-tree.md`, the new doctrine page extending mcp-wraps-cli-pattern). Solves construct-mibera-codex#62 (grail image URL discovery friction).
+
+Surface delivered:
+- 8 CLI subcommands mirroring 8 MCP tools 1:1 (parallel verbs, cross-construct legibility invariant)
+- Slug convention documented in `grails/README.md` (lowercase + hyphens + `.png`) with provenance back to issue #62
+- `lookup_grail` MCP tool description updated to surface `image` / `original_image` / `attributes` fields explicitly; same `src/lookups/grail.ts` reads serve both surfaces (data-as-truth)
+- `GrailEntry` type extended with `image` / `original_image` / `attributes[]` fields to match the canonical NFT-metadata shape now in `_codex/data/grails.jsonl`
+
+Spec deviations (per `feedback_spec_deviation_pattern` — surface in NOTES, don't avoid):
+
+1. **Bare argv parsing instead of commander.js / yargs** (seed §4.2 mentioned either). Reason: keeps deps stable (no lockfile churn); `--help` is hand-written, which lets it match MCP tool descriptions character-for-character per ALEXANDER craft lens. Trade-off: ~70 lines more code; commander would have given typo suggestions for free.
+2. **Initial v1 added an `image_url` field to grails.jsonl on the working branch; on rebase to main this collided with main's already-shipped `image` / `original_image` / `attributes` shape** (migrate-cdn-urls.py migration). Resolved by deferring to main's canonical shape — session 07 owns the *CLI surface* and the *slug-convention documentation*, not the data layer. Field references throughout the session 07 doctrine + bonfire reference + CLI examples were renamed `image_url` → `image` to match.
+3. **`GrailEntry.slug` formalized as required field** (was previously cast-as-optional with `e as GrailEntry & { slug?: string }` in `src/lookups/grail.ts`). Pre-existing data has `slug` for all 43 entries; the type now reflects ground truth. No runtime change.
+
+Doctrine note: this construct is now the reference implementation for bucket-1 (per `construct-surface-decision-tree.md` §5 worked example). Other MCP-only constructs (rosenzu, emojis, freeside_auth) are V2 candidates — wait for second-instance friction before generalizing.
+
+V1.5 deferred: KEEPER pass with Adasuna (external Loa user) — validate the install + invocation flow when accessed via `loa /constructs install mibera-codex` rather than this repo's local dev path.
+
 ### P2 Item 1: Schema meta blocks with confidence levels — IMPLEMENTED (Cycle 012)
 Added `x-codex-confidence` and `x-codex-source` annotations to all 65 fields across 8 schema files. Used JSON Schema `x-` extension mechanism (non-breaking). Three confidence levels: canonical (77%), derived (1.5%), community (21.5%). Seven source types: contract-metadata, project-lore, project-asset, editorial, research, artist, classification.
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "description": "Mibera Codex MCP server — anti-hallucination lookup for narrative-bot consumers (zones, archetypes, factors, grails, miberas).",
   "type": "module",
   "bin": {
+    "codex": "./dist/bin/codex.js",
     "codex-mcp": "./dist/bin/mcp.js"
   },
   "scripts": {
     "build": "tsc",
+    "codex": "tsx bin/codex.ts",
+    "codex:dev": "tsx watch bin/codex.ts",
     "mcp": "tsx bin/mcp.ts",
     "mcp:dev": "tsx watch bin/mcp.ts",
     "prepublishOnly": "tsc"

--- a/src/lookups/grail.ts
+++ b/src/lookups/grail.ts
@@ -30,7 +30,7 @@ function loadGrails(): GrailCache {
       continue;
     }
     if (typeof parsed !== "object" || parsed === null) continue;
-    const e = parsed as GrailEntry & { slug?: string };
+    const e = parsed as GrailEntry;
     if (typeof e.id === "number") byId.set(e.id, e);
     if (typeof e.slug === "string") bySlug.set(e.slug.toLowerCase(), e);
     if (typeof e.name === "string") byName.set(e.name.toLowerCase(), e);

--- a/src/lookups/grail.ts
+++ b/src/lookups/grail.ts
@@ -31,9 +31,16 @@ function loadGrails(): GrailCache {
     }
     if (typeof parsed !== "object" || parsed === null) continue;
     const e = parsed as GrailEntry;
+    // `slug` and `name` are required per the GrailEntry type — fail loud at
+    // load time if a row drifts. `id` is optional (older entries may lack it).
+    if (typeof e.slug !== "string" || typeof e.name !== "string") {
+      throw new Error(
+        `grail entry missing required slug/name field: ${JSON.stringify(parsed)}`,
+      );
+    }
     if (typeof e.id === "number") byId.set(e.id, e);
-    if (typeof e.slug === "string") bySlug.set(e.slug.toLowerCase(), e);
-    if (typeof e.name === "string") byName.set(e.name.toLowerCase(), e);
+    bySlug.set(e.slug.toLowerCase(), e);
+    byName.set(e.name.toLowerCase(), e);
   }
 
   cache = { byId, bySlug, byName };

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,7 +87,7 @@ export function createCodexMcpServer(): McpServer {
 
   server.tool(
     "lookup_grail",
-    "Look up a 1/1 grail by token ID, slug, or display name. Returns id, name, category (element/luminary/concept/zodiac/planet/ancestor/primordial/special/community), description, status. Returns null if not found.",
+    "Look up a 1/1 grail by token ID, slug, or display name. Returns id, name, slug, category (element/luminary/concept/zodiac/planet/ancestor/primordial/special/community), description, image (CDN URL), original_image (legacy irys URL), and attributes (NFT-metadata array). The image field follows the convention https://assets.0xhoneyjar.xyz/Mibera/grails/{slug}.png — slug is lowercase + spaces-replaced-with-hyphens. Returns null if not found.",
     z.object({
       query: z
         .string()

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,7 +87,7 @@ export function createCodexMcpServer(): McpServer {
 
   server.tool(
     "lookup_grail",
-    "Look up a 1/1 grail by token ID, slug, or display name. Returns id, name, slug, category (element/luminary/concept/zodiac/planet/ancestor/primordial/special/community), description, image (CDN URL), original_image (legacy irys URL), and attributes (NFT-metadata array). The image field follows the convention https://assets.0xhoneyjar.xyz/Mibera/grails/{slug}.png — slug is lowercase + spaces-replaced-with-hyphens. Returns null if not found.",
+    "Look up a 1/1 grail by token ID, slug, or display name. Returns id, name, slug, category (element/luminary/concept/zodiac/planet/ancestor/primordial/special/community), description, image (CDN URL), original_image (legacy irys URL), and attributes (NFT-metadata array). Read the `image` field directly; the slug-derivation convention is documented in grails/README.md (canonical authority). Returns null if not found.",
     z.object({
       query: z
         .string()

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,11 @@ export interface MiberaEntry {
   parcel?: number;
 }
 
+export interface GrailAttribute {
+  trait_type: string;
+  value: string;
+}
+
 export interface GrailEntry {
   id?: number;
   name: string;
@@ -89,7 +94,11 @@ export interface GrailEntry {
     | "primordial"
     | "special"
     | "community";
+  slug: string;
   description?: string;
+  image?: string;
+  original_image?: string;
+  attributes?: GrailAttribute[];
   commissioned_for?: string;
   status?: "on-chain" | "pending";
 }


### PR DESCRIPTION
## Summary

Ships `bin/codex.ts` as the **bucket-1 CLI half** for mibera-codex, per the new vault doctrine `~/vault/wiki/concepts/construct-surface-decision-tree.md` (4-bucket tree extending `mcp-wraps-cli-pattern`).

Bucket 1 = stateless data-shaped construct with both human + agent consumers → CLI primary, MCP wraps. mibera-codex is the reference impl going forward.

8 subcommands mirror the 8 MCP tools 1:1 (parallel verbs, cross-construct legibility invariant):

```bash
codex lookup zone|archetype|factor|grail|mibera <query>
codex list zones|archetypes
codex validate <type> <value>
```

Output: stdout JSON · `--field=<name>` for raw extraction (pipeable into shell). Exit codes: `0` success / `1` not_found / `2` usage_error.

## Closes #62 — grail image URL discovery friction

Issue author Adeitasuna empirically discovered the lowercase + hyphens + `.png` slug convention through ~14 HEAD probes per multi-word grail name. This PR closes the gap on three axes:

1. **CLI** — one deterministic call:
   ```bash
   codex lookup grail black-hole --field=image
   # → https://assets.0xhoneyjar.xyz/Mibera/grails/black-hole.png
   ```
2. **MCP** — `lookup_grail({query: "black-hole"})` returns `image` / `original_image` / `attributes` fields automatically (data flows through; `src/lookups/grail.ts` is shared between CLI and MCP).
3. **Docs** — `grails/README.md` now documents the slug convention with provenance back to #62 and the empirical examples (`Black Hole` → `black-hole.png`, `Native American` → `native-american.png`).

## Test plan

- [x] `pnpm exec tsc --noEmit` exits 0
- [x] `pnpm build` produces `dist/bin/codex.js` with shebang preserved
- [x] `node dist/bin/codex.js lookup grail black-hole --field=image` → URL on first try
- [x] `node dist/bin/codex.js --version` → `1.1.0`
- [x] All 5 lookup verbs + 2 list verbs + validate verb smoke-tested
- [x] Error paths verified (not_found exit 1, usage error exit 2)
- [x] CLI and MCP load from the same `src/lookups/grail.ts` (no logic duplication)

## Doctrine + composition

Worked example for the new vault doctrine: `~/vault/wiki/concepts/construct-surface-decision-tree.md` (4-bucket tree, session 07 V1 deliverable).

Composes with:
- `~/vault/wiki/concepts/mcp-wraps-cli-pattern.md` (parent · 2026-04-16) — every CLI gets an MCP mirror
- `~/vault/wiki/concepts/constructs-mcp-shape.md` (sibling) — 4-op surface (lookup/list/validate/describe)
- `~/vault/wiki/concepts/constructs-mcp-deployment-topology.md` (sibling) — 3 host paths

Org-internal reference: `~/bonfire/grimoires/bonfire/specs/construct-surface-by-audience-2026-05-02.md` (Loa-internal vs external-agent split).

## Spec deviations (surfaced in NOTES.md per `feedback_spec_deviation_pattern`)

1. **Bare argv parsing** instead of commander.js / yargs — keeps deps stable; `--help` is hand-written which lets it match MCP tool descriptions character-for-character (ALEXANDER craft lens). +~70 lines, no commander typo-suggestions.
2. **Field-name harmonization on rebase** — initial v1 added `image_url` to grails.jsonl on the working branch; on rebase to main this collided with main's already-shipped `image`/`original_image`/`attributes` shape (migrate-cdn-urls.py). Resolved by deferring to main's canonical shape — this PR owns the *CLI surface* and the *slug-convention documentation*, not the data layer. Field references throughout doctrine + bonfire reference + CLI examples renamed `image_url` → `image`.
3. **`GrailEntry.slug` formalized** as required (was previously cast-as-optional). Pre-existing data has slug for all 43 entries; type now reflects ground truth. No runtime change.

## Independent of PR #57 (Path-B HTTP transport)

This PR branches off main, does NOT include the `codex-mcp-http` / Railway changes from `feat/codex-mcp-path-b`. CLI surface is local-always (per `gateway-as-registry`); independent of the MCP host path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)