### PR TITLE
feat(lookup): lookup_mst — Mibera Shadow Traits per-token enrichment (companion to URL_CONTRACT v1.2.0)

### DIFF
--- a/_codex/data/mst-collection.json
+++ b/_codex/data/mst-collection.json
@@ -5,6 +5,7 @@
   "standard": "ERC-721 (UUPS Proxy)",
   "tokenSymbol": "MST",
   "name": "Mibera Shadow Traits",
+  "narrativeAliases": ["Shadow", "Mibera Shadows", "MST"],
   "totalSupplyKnown": 3219,
   "narrativeRef": "_codex/data/shadow-traits.md",
   "metadata": {
@@ -14,21 +15,30 @@
   },
   "stickers": {
     "manifestUrl": "https://assets.0xhoneyjar.xyz/Mibera/MST/expressions/current.json",
-    "version": "v1",
+    "shadowAliasManifestUrl": "https://assets.0xhoneyjar.xyz/Mibera/Shadow/expressions/current.json",
+    "version": "v2",
     "expressionsAvailable": [
       "neutral",
-      "smile",
       "angry",
-      "surprised",
+      "aww",
       "sad",
-      "sleepy",
-      "wink"
+      "uneasy",
+      "yay",
+      "smirk",
+      "worried",
+      "shocked",
+      "devious",
+      "tearful",
+      "grumpy",
+      "bashful",
+      "fierce",
+      "bliss"
     ],
-    "variants": ["transparent"],
+    "variants": ["transparent", "bg"],
     "defaultVariant": "transparent",
     "perTokenBaseUrlTemplate": "https://assets.0xhoneyjar.xyz/Mibera/MST/expressions/{version}/{tokenId}/{variant}/{expr}.webp",
     "substrateStatus": "pending",
-    "substrateNotes": "URL_CONTRACT v1.2.0 (freeside-storage#6) registers these paths. Substrate bytes pending M-1 (S3 bucket policy) + M-2 (sticker generation pipeline) — see bonfire substrate handoff brief 2026-05-02. Until live, perToken URLs return 403; manifest URL returns 403."
+    "substrateNotes": "Catalog mirrored from live canon Mibera manifest at https://assets.0xhoneyjar.xyz/Mibera/expressions/current.json (version v2, 15 expressions, 2 variants — matches expressionCount). Expression slugs sourced from mibera-dimensions/lib/emoji/expression-presets.ts (consumer-side authoritative list). Shadow + MST are alias paths to the same collection (per shadow-traits.md: 'Mibera Shadow Traits' technically MST, narratively Shadow); URL_CONTRACT v1.2.0 registers both substrate paths for transitional consumer compat. Sticker substrate bytes pending M-1 (S3 bucket policy) + M-2 (sticker generation pipeline) of mibera-family-sticker-substrate cycle — until live, perToken URLs return 403 on both paths."
   },
   "urlContractRef": {
     "version": "1.2.0",

--- a/_codex/data/mst-collection.json
+++ b/_codex/data/mst-collection.json
@@ -1,0 +1,38 @@
+{
+  "contract": "0x048327A187b944ddac61c6e202BfccD20d17c008",
+  "chain": "berachain",
+  "chainId": 80094,
+  "standard": "ERC-721 (UUPS Proxy)",
+  "tokenSymbol": "MST",
+  "name": "Mibera Shadow Traits",
+  "totalSupplyKnown": 3219,
+  "narrativeRef": "_codex/data/shadow-traits.md",
+  "metadata": {
+    "sovereignTokenURITemplate": "https://metadata.0xhoneyjar.xyz/mibera/mst/{tokenId}",
+    "shippedAt": "2026-05-01",
+    "cycle": "migrate-mst-sovereignty-2026-05-01"
+  },
+  "stickers": {
+    "manifestUrl": "https://assets.0xhoneyjar.xyz/Mibera/MST/expressions/current.json",
+    "version": "v1",
+    "expressionsAvailable": [
+      "neutral",
+      "smile",
+      "angry",
+      "surprised",
+      "sad",
+      "sleepy",
+      "wink"
+    ],
+    "variants": ["transparent"],
+    "defaultVariant": "transparent",
+    "perTokenBaseUrlTemplate": "https://assets.0xhoneyjar.xyz/Mibera/MST/expressions/{version}/{tokenId}/{variant}/{expr}.webp",
+    "substrateStatus": "pending",
+    "substrateNotes": "URL_CONTRACT v1.2.0 (freeside-storage#6) registers these paths. Substrate bytes pending M-1 (S3 bucket policy) + M-2 (sticker generation pipeline) — see bonfire substrate handoff brief 2026-05-02. Until live, perToken URLs return 403; manifest URL returns 403."
+  },
+  "urlContractRef": {
+    "version": "1.2.0",
+    "schemaUrl": "https://github.com/0xHoneyJar/freeside-storage/blob/main/packages/protocol/url-contract.schema.json",
+    "migrationPhaseId": "mibera-family-sticker-substrate"
+  }
+}

--- a/bin/micodex.ts
+++ b/bin/micodex.ts
@@ -26,7 +26,7 @@ import {
 import { lookupFactor } from "../src/lookups/factor.js";
 import { lookupGrail } from "../src/lookups/grail.js";
 import { lookupMibera } from "../src/lookups/mibera.js";
-import { lookupMst } from "../src/lookups/mst.js";
+import { lookupMst, lookupShadow } from "../src/lookups/mst.js";
 import {
   searchCodex,
   QmdNotInstalledError,
@@ -115,7 +115,7 @@ Usage:
   micodex <command> [args] [flags]
 
 Commands:
-  lookup <noun> <query>    Look up a single entity (zone / archetype / factor / grail / mibera / mst)
+  lookup <noun> <query>    Look up a single entity (zone / archetype / factor / grail / mibera / mst / shadow)
   list <noun>              List canonical entities (zones / archetypes)
   validate <type> <value>  Validate a value against the canonical set (suggests closest)
   search <intent>          Intent-layer search — returns ranked refs for \`lookup\`
@@ -133,6 +133,7 @@ Examples:
   micodex lookup factor nft:mibera
   micodex lookup mibera 4488
   micodex lookup mst 123                            # MST (Mibera Shadow Traits) per-token enrichment
+  micodex lookup shadow 123                         # alias for mst — same data, @shadow<N> ref form
   micodex list zones
   micodex validate archetype Freetech
   micodex search "void motif" --collection=grails  # intent → ref envelope (JSON)
@@ -150,6 +151,7 @@ Usage:
   micodex lookup grail <id|slug|name>    Look up a 1/1 grail (token ID, slug, or display name)
   micodex lookup mibera <token-id>       Look up a single Mibera by token ID (1-10000)
   micodex lookup mst <token-id>          Look up MST (Mibera Shadow Traits) per-token (sovereign metadata + sticker URLs)
+  micodex lookup shadow <token-id>       Alias for mst — Shadow ≡ MST per shadow-traits.md (returns @shadow<N> ref form)
 
 Flags:
   --field=<name>                       Extract a single field from the result (raw output)
@@ -234,17 +236,37 @@ function handleLookup(rest: string[], flags: Record<string, string | boolean>): 
     }
     case "mst": {
       if (!query) fail("missing token-id. usage: micodex lookup mst <token-id>");
-      // accept the @mst<N> ref as well as bare numeric
-      const stripped = query.startsWith("@mst") ? query.slice(4) : query;
+      // accept @mst<N>, @shadow<N>, or bare numeric (Shadow ≡ MST per shadow-traits.md)
+      const stripped = query.startsWith("@mst")
+        ? query.slice(4)
+        : query.startsWith("@shadow")
+          ? query.slice(7)
+          : query;
       const id = Number(stripped);
       if (!Number.isFinite(id) || !Number.isInteger(id) || id < 1) {
-        fail(`invalid token-id "${query}" — must be a positive integer (or @mst<id> ref)`);
+        fail(`invalid token-id "${query}" — must be a positive integer (or @mst<id> / @shadow<id> ref)`);
       }
       emit(lookupMst(id), field);
       break;
     }
+    case "shadow": {
+      // Shadow ≡ MST alias (per shadow-traits.md: "Mibera Shadow Traits" technically
+      // MST, narratively Shadow). Same data, returns `@shadow<N>` ref form.
+      if (!query) fail("missing token-id. usage: micodex lookup shadow <token-id>");
+      const stripped = query.startsWith("@shadow")
+        ? query.slice(7)
+        : query.startsWith("@mst")
+          ? query.slice(4)
+          : query;
+      const id = Number(stripped);
+      if (!Number.isFinite(id) || !Number.isInteger(id) || id < 1) {
+        fail(`invalid token-id "${query}" — must be a positive integer (or @shadow<id> / @mst<id> ref)`);
+      }
+      emit(lookupShadow(id), field);
+      break;
+    }
     default:
-      fail(`unknown noun "${noun}". expected: zone, archetype, factor, grail, mibera, mst`);
+      fail(`unknown noun "${noun}". expected: zone, archetype, factor, grail, mibera, mst, shadow`);
   }
 }
 

--- a/bin/micodex.ts
+++ b/bin/micodex.ts
@@ -26,6 +26,7 @@ import {
 import { lookupFactor } from "../src/lookups/factor.js";
 import { lookupGrail } from "../src/lookups/grail.js";
 import { lookupMibera } from "../src/lookups/mibera.js";
+import { lookupMst } from "../src/lookups/mst.js";
 import {
   searchCodex,
   QmdNotInstalledError,
@@ -114,7 +115,7 @@ Usage:
   micodex <command> [args] [flags]
 
 Commands:
-  lookup <noun> <query>    Look up a single entity (zone / archetype / factor / grail / mibera)
+  lookup <noun> <query>    Look up a single entity (zone / archetype / factor / grail / mibera / mst)
   list <noun>              List canonical entities (zones / archetypes)
   validate <type> <value>  Validate a value against the canonical set (suggests closest)
   search <intent>          Intent-layer search — returns ranked refs for \`lookup\`
@@ -131,6 +132,7 @@ Examples:
   micodex lookup archetype Freetekno
   micodex lookup factor nft:mibera
   micodex lookup mibera 4488
+  micodex lookup mst 123                            # MST (Mibera Shadow Traits) per-token enrichment
   micodex list zones
   micodex validate archetype Freetech
   micodex search "void motif" --collection=grails  # intent → ref envelope (JSON)
@@ -147,6 +149,7 @@ Usage:
   micodex lookup factor <factor-id>      Look up a score-mibera factor and return its codex lore
   micodex lookup grail <id|slug|name>    Look up a 1/1 grail (token ID, slug, or display name)
   micodex lookup mibera <token-id>       Look up a single Mibera by token ID (1-10000)
+  micodex lookup mst <token-id>          Look up MST (Mibera Shadow Traits) per-token (sovereign metadata + sticker URLs)
 
 Flags:
   --field=<name>                       Extract a single field from the result (raw output)
@@ -229,8 +232,19 @@ function handleLookup(rest: string[], flags: Record<string, string | boolean>): 
       emit(lookupMibera(id), field);
       break;
     }
+    case "mst": {
+      if (!query) fail("missing token-id. usage: micodex lookup mst <token-id>");
+      // accept the @mst<N> ref as well as bare numeric
+      const stripped = query.startsWith("@mst") ? query.slice(4) : query;
+      const id = Number(stripped);
+      if (!Number.isFinite(id) || !Number.isInteger(id) || id < 1) {
+        fail(`invalid token-id "${query}" — must be a positive integer (or @mst<id> ref)`);
+      }
+      emit(lookupMst(id), field);
+      break;
+    }
     default:
-      fail(`unknown noun "${noun}". expected: zone, archetype, factor, grail, mibera`);
+      fail(`unknown noun "${noun}". expected: zone, archetype, factor, grail, mibera, mst`);
   }
 }
 

--- a/skills/query-entity/SKILL.md
+++ b/skills/query-entity/SKILL.md
@@ -21,6 +21,7 @@ micodex lookup zone bear-cave
 micodex lookup archetype Freetekno
 micodex lookup factor nft:mibera
 micodex lookup mibera 4488
+micodex lookup mst 123                  # MST (Mibera Shadow Traits) — sovereign metadata + sticker URLs
 ```
 
 Single deterministic call. Returns the full entity JSON. Exits 1 on not_found.
@@ -69,11 +70,29 @@ micodex validate archetype Freetech
 # {"canonical": false, "suggested": "Freetekno", "distance": 1, ...}
 ```
 
+## MST — Mibera Shadow Traits
+
+```bash
+micodex lookup mst 123
+```
+
+Returns enriched envelope:
+- `collection.{contract, chain, standard, name, symbol}` — on-chain identity
+- `metadata.sovereignUrl` — `metadata.0xhoneyjar.xyz/mibera/mst/{N}` (sovereign tokenURI · LIVE post-Cutover B 2026-05-01)
+- `stickers.urls[<expression>]` — per-expression sticker URLs composed against URL_CONTRACT v1.2.0 paths under `Mibera/MST/expressions/...`
+- `stickers.substrateStatus` — `"pending"` until M-1 (S3 bucket policy) + M-2 (generation pipeline) of mibera-family-sticker-substrate cycle land; sticker URLs return 403 until then
+
+MST tokens are dynamically user-minted via trait strings hashed keccak256 on-chain (see `_codex/data/shadow-traits.md`). There's no per-token JSONL — the lookup composes URLs from the collection-level template + the requested tokenId. Total supply known as of 2026-05-01: 3219.
+
+For canonical names → ref:
+- `@mst<tokenId>` is the stable ref (mirrors `@g<id>` for grails). `lookup mst @mst123` and `lookup mst 123` are equivalent.
+
 ## Bulk / structured access
 
 For programmatic exhaustive queries:
 - `_codex/data/miberas.jsonl` — all 10,000 Miberas (JSONL)
 - `_codex/data/grails.jsonl` — 43 grails (JSONL)
+- `_codex/data/mst-collection.json` — MST collection-level metadata + sticker config (one entry · per-token URLs composed via `lookup mst`)
 - `_codex/data/graph.json` — full knowledge graph (5.9 MB)
 
 Prefer the CLI for single-entity queries; the JSONL/graph dumps are for batch processing.

--- a/skills/query-entity/SKILL.md
+++ b/skills/query-entity/SKILL.md
@@ -21,7 +21,6 @@ micodex lookup zone bear-cave
 micodex lookup archetype Freetekno
 micodex lookup factor nft:mibera
 micodex lookup mibera 4488
-micodex lookup mst 123                  # MST (Mibera Shadow Traits) — sovereign metadata + sticker URLs
 ```
 
 Single deterministic call. Returns the full entity JSON. Exits 1 on not_found.
@@ -70,29 +69,11 @@ micodex validate archetype Freetech
 # {"canonical": false, "suggested": "Freetekno", "distance": 1, ...}
 ```
 
-## MST — Mibera Shadow Traits
-
-```bash
-micodex lookup mst 123
-```
-
-Returns enriched envelope:
-- `collection.{contract, chain, standard, name, symbol}` — on-chain identity
-- `metadata.sovereignUrl` — `metadata.0xhoneyjar.xyz/mibera/mst/{N}` (sovereign tokenURI · LIVE post-Cutover B 2026-05-01)
-- `stickers.urls[<expression>]` — per-expression sticker URLs composed against URL_CONTRACT v1.2.0 paths under `Mibera/MST/expressions/...`
-- `stickers.substrateStatus` — `"pending"` until M-1 (S3 bucket policy) + M-2 (generation pipeline) of mibera-family-sticker-substrate cycle land; sticker URLs return 403 until then
-
-MST tokens are dynamically user-minted via trait strings hashed keccak256 on-chain (see `_codex/data/shadow-traits.md`). There's no per-token JSONL — the lookup composes URLs from the collection-level template + the requested tokenId. Total supply known as of 2026-05-01: 3219.
-
-For canonical names → ref:
-- `@mst<tokenId>` is the stable ref (mirrors `@g<id>` for grails). `lookup mst @mst123` and `lookup mst 123` are equivalent.
-
 ## Bulk / structured access
 
 For programmatic exhaustive queries:
 - `_codex/data/miberas.jsonl` — all 10,000 Miberas (JSONL)
 - `_codex/data/grails.jsonl` — 43 grails (JSONL)
-- `_codex/data/mst-collection.json` — MST collection-level metadata + sticker config (one entry · per-token URLs composed via `lookup mst`)
 - `_codex/data/graph.json` — full knowledge graph (5.9 MB)
 
 Prefer the CLI for single-entity queries; the JSONL/graph dumps are for batch processing.

--- a/src/lookups/mst.ts
+++ b/src/lookups/mst.ts
@@ -1,0 +1,132 @@
+/**
+ * MST (Mibera Shadow Traits) lookup.
+ *
+ * MST is fundamentally different from canon Mibera: each token is dynamically
+ * minted by users submitting a trait string that's hashed keccak256 on-chain
+ * (see `_codex/data/shadow-traits.md`). There's no per-token curated record.
+ * Instead, the codex publishes COLLECTION-level metadata + URL templates;
+ * `lookupMst(tokenId)` enriches a tokenId with composed URLs (sovereign
+ * metadata + per-expression sticker URLs).
+ *
+ * Companion to URL_CONTRACT v1.2.0 (freeside-storage#6) which formally
+ * registers the sticker substrate paths under `Mibera/MST/expressions/...`.
+ *
+ * Substrate state at v1.4.x:
+ *   - Sovereign metadata: LIVE (mst-sovereign-cutover · 2026-05-01)
+ *   - Sticker substrate: PENDING M-1 (S3 bucket policy) + M-2 (gen pipeline)
+ *     · per-token sticker URLs return 403 until those land
+ *
+ * Agents reading this map: call `lookupMst(tokenId)` to get the enriched
+ * envelope. The `stickers.urls` field is the lookup table you want.
+ */
+
+import { readFileSync } from "node:fs";
+import { codexPath } from "../lib/codex-root.js";
+import type { MstCollection, MstEntry } from "../types.js";
+
+const MST_COLLECTION_JSON = "_codex/data/mst-collection.json";
+
+let cache: MstCollection | null = null;
+
+function loadCollection(): MstCollection {
+  if (cache) return cache;
+  const raw = readFileSync(codexPath(MST_COLLECTION_JSON), "utf8");
+  const parsed = JSON.parse(raw) as MstCollection;
+  cache = parsed;
+  return cache;
+}
+
+/**
+ * Compose the per-token sticker URL for a single expression.
+ * Substitutes `{version}` / `{tokenId}` / `{variant}` / `{expr}` into the
+ * collection's `perTokenBaseUrlTemplate`.
+ */
+function composeStickerUrl(
+  template: string,
+  version: string,
+  tokenId: number,
+  variant: string,
+  expression: string,
+): string {
+  return template
+    .replace("{version}", version)
+    .replace("{tokenId}", String(tokenId))
+    .replace("{variant}", variant)
+    .replace("{expr}", expression);
+}
+
+/**
+ * Look up an MST token by tokenId — enriches with sovereign metadata URL
+ * and per-expression sticker URLs (composed at call time from collection
+ * template + the requested tokenId).
+ *
+ * Returns `null` for tokenIds outside the known supply range. Note that
+ * "in range" doesn't guarantee the token was actually minted — MST is
+ * sequentially minted by users, so the in-range check is a heuristic.
+ * Use the on-chain `tokenURI` call for definitive existence; this lookup
+ * is for URL composition.
+ */
+export function lookupMst(tokenId: number): MstEntry | null {
+  if (!Number.isInteger(tokenId) || tokenId < 1) return null;
+
+  const c = loadCollection();
+  if (tokenId > c.totalSupplyKnown) return null;
+
+  const sovereignUrl = c.metadata.sovereignTokenURITemplate.replace(
+    "{tokenId}",
+    String(tokenId),
+  );
+
+  const urls: Record<string, string> = {};
+  for (const expr of c.stickers.expressionsAvailable) {
+    urls[expr] = composeStickerUrl(
+      c.stickers.perTokenBaseUrlTemplate,
+      c.stickers.version,
+      tokenId,
+      c.stickers.defaultVariant,
+      expr,
+    );
+  }
+
+  return {
+    type: "mst",
+    ref: `@mst${tokenId}`,
+    tokenId,
+    collection: {
+      contract: c.contract,
+      chain: c.chain,
+      standard: c.standard,
+      name: c.name,
+      symbol: c.tokenSymbol,
+    },
+    metadata: {
+      sovereignUrl,
+    },
+    stickers: {
+      manifestUrl: c.stickers.manifestUrl,
+      version: c.stickers.version,
+      expressionsAvailable: c.stickers.expressionsAvailable,
+      variants: c.stickers.variants,
+      defaultVariant: c.stickers.defaultVariant,
+      urls,
+      substrateStatus: c.stickers.substrateStatus,
+      ...(c.stickers.substrateNotes && {
+        substrateNotes: c.stickers.substrateNotes,
+      }),
+    },
+  };
+}
+
+/**
+ * Return the MST collection-level metadata (without per-token enrichment).
+ * Useful for `list` / `validate` operations and for consumers who just need
+ * the substrate config (manifest URL, expression catalog, version).
+ */
+export function getMstCollection(): MstCollection {
+  return loadCollection();
+}
+
+/** Reset the cache — exposed for tests + integration scripts. */
+export function resetMstCache(): void {
+  cache = null;
+}

--- a/src/lookups/mst.ts
+++ b/src/lookups/mst.ts
@@ -130,3 +130,20 @@ export function getMstCollection(): MstCollection {
 export function resetMstCache(): void {
   cache = null;
 }
+
+/**
+ * `lookupShadow` — alias for `lookupMst`. Per `_codex/data/shadow-traits.md`
+ * MST = "Mibera Shadow Traits"; "Shadow" is the narrative name, MST is the
+ * technical contract symbol. URL_CONTRACT v1.2.0 registers BOTH path
+ * conventions (`Mibera/Shadow/expressions/*` and `Mibera/MST/expressions/*`)
+ * for transitional consumer compat; this alias mirrors that on the lookup
+ * side so agents querying either name resolve to the same enriched envelope.
+ *
+ * Returned `type` stays `"mst"` (technical truth) but `ref` uses the
+ * `@shadow<N>` form to preserve the input vocabulary in the response.
+ */
+export function lookupShadow(tokenId: number): MstEntry | null {
+  const entry = lookupMst(tokenId);
+  if (!entry) return null;
+  return { ...entry, ref: `@shadow${tokenId}` };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { lookupArchetype, listArchetypes } from "./lookups/archetype.js";
 import { lookupFactor } from "./lookups/factor.js";
 import { lookupGrail } from "./lookups/grail.js";
 import { lookupMibera } from "./lookups/mibera.js";
+import { lookupMst } from "./lookups/mst.js";
 import {
   searchCodex,
   QmdNotInstalledError,
@@ -136,6 +137,31 @@ export function createCodexMcpServer(): McpServer {
           {
             type: "text",
             text: m ? JSON.stringify(m, null, 2) : JSON.stringify({ error: "not_found", id }),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "lookup_mst",
+    "Look up an MST (Mibera Shadow Traits) token by tokenId. Returns sovereign metadata URL (metadata.0xhoneyjar.xyz/mibera/mst/{N} — LIVE) + per-expression sticker URLs (composed from URL_CONTRACT v1.2.0 paths under Mibera/MST/expressions/). MST is dynamically minted via user-submitted trait strings hashed keccak256 on-chain (3219 known minted as of 2026-05-01); per-token data is composed at lookup time, not stored. Sticker substrate is PENDING M-1 (S3 bucket policy) + M-2 (sticker generation pipeline) of mibera-family-sticker-substrate cycle — sticker URLs return 403 until those land. See _codex/data/shadow-traits.md for contract mechanics.",
+    z.object({
+      tokenId: z
+        .number()
+        .int()
+        .min(1)
+        .describe("MST tokenId (positive integer; 1-3219 known minted, may grow)"),
+    }).shape,
+    async ({ tokenId }) => {
+      const m = lookupMst(tokenId);
+      return {
+        content: [
+          {
+            type: "text",
+            text: m
+              ? JSON.stringify(m, null, 2)
+              : JSON.stringify({ error: "not_found", tokenId }),
           },
         ],
       };

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { lookupArchetype, listArchetypes } from "./lookups/archetype.js";
 import { lookupFactor } from "./lookups/factor.js";
 import { lookupGrail } from "./lookups/grail.js";
 import { lookupMibera } from "./lookups/mibera.js";
-import { lookupMst } from "./lookups/mst.js";
+import { lookupMst, lookupShadow } from "./lookups/mst.js";
 import {
   searchCodex,
   QmdNotInstalledError,
@@ -145,7 +145,7 @@ export function createCodexMcpServer(): McpServer {
 
   server.tool(
     "lookup_mst",
-    "Look up an MST (Mibera Shadow Traits) token by tokenId. Returns sovereign metadata URL (metadata.0xhoneyjar.xyz/mibera/mst/{N} — LIVE) + per-expression sticker URLs (composed from URL_CONTRACT v1.2.0 paths under Mibera/MST/expressions/). MST is dynamically minted via user-submitted trait strings hashed keccak256 on-chain (3219 known minted as of 2026-05-01); per-token data is composed at lookup time, not stored. Sticker substrate is PENDING M-1 (S3 bucket policy) + M-2 (sticker generation pipeline) of mibera-family-sticker-substrate cycle — sticker URLs return 403 until those land. See _codex/data/shadow-traits.md for contract mechanics.",
+    "Look up an MST (Mibera Shadow Traits) token by tokenId. Returns sovereign metadata URL (metadata.0xhoneyjar.xyz/mibera/mst/{N} — LIVE post-Cutover B 2026-05-01) + per-expression sticker URLs (15 expressions composed from URL_CONTRACT v1.2.0 paths under Mibera/MST/expressions/v2/, mirroring canon Mibera v2 manifest). MST is dynamically minted via user-submitted trait strings hashed keccak256 on-chain (3219 known minted as of 2026-05-01); per-token data is composed at lookup time, not stored. Sticker substrate is PENDING M-1 (S3 bucket policy) + M-2 (sticker generation pipeline) of mibera-family-sticker-substrate cycle — sticker URLs return 403 until those land. See _codex/data/shadow-traits.md for contract mechanics. Alias: lookup_shadow (same collection, @shadow<N> ref form).",
     z.object({
       tokenId: z
         .number()
@@ -155,6 +155,31 @@ export function createCodexMcpServer(): McpServer {
     }).shape,
     async ({ tokenId }) => {
       const m = lookupMst(tokenId);
+      return {
+        content: [
+          {
+            type: "text",
+            text: m
+              ? JSON.stringify(m, null, 2)
+              : JSON.stringify({ error: "not_found", tokenId }),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "lookup_shadow",
+    "Alias for lookup_mst. Per _codex/data/shadow-traits.md, MST = 'Mibera Shadow Traits' — narratively Shadow, technically MST. Same tokens, same on-chain contract, same sticker substrate (15 expressions at v2). URL_CONTRACT v1.2.0 registers BOTH path conventions (Mibera/Shadow/expressions/* and Mibera/MST/expressions/*) for transitional consumer compat. Returns identical envelope to lookup_mst with @shadow<N> ref form.",
+    z.object({
+      tokenId: z
+        .number()
+        .int()
+        .min(1)
+        .describe("Shadow/MST tokenId (positive integer; 1-3219 known minted, may grow)"),
+    }).shape,
+    async ({ tokenId }) => {
+      const m = lookupShadow(tokenId);
       return {
         content: [
           {

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,7 +109,8 @@ export type WorldElementType =
   | "factor"
   | "grail"
   | "mibera"
-  | "mst";
+  | "mst"
+  | "shadow";
 
 /**
  * Sticker catalog — shape mirrored from URL_CONTRACT v1.2.0 + StickerProfile.

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,7 +103,97 @@ export interface GrailEntry {
   status?: "on-chain" | "pending";
 }
 
-export type WorldElementType = "zone" | "archetype" | "factor" | "grail" | "mibera";
+export type WorldElementType =
+  | "zone"
+  | "archetype"
+  | "factor"
+  | "grail"
+  | "mibera"
+  | "mst";
+
+/**
+ * Sticker catalog — shape mirrored from URL_CONTRACT v1.2.0 + StickerProfile.
+ * Used by `MstEntry` and reusable for future Mibera-family sub-collections
+ * (Shadow · Tarot · Candies · GIF · Fractures) as they ship sticker substrate.
+ *
+ * `expressionsAvailable` is the LORE — what facial states this collection
+ * supports. Default to V0.6.x baseline (Mibera canon) until a per-collection
+ * catalog supersedes it (PRD O-4 future scope).
+ */
+export interface StickerCatalog {
+  manifestUrl: string;
+  version: string;
+  expressionsAvailable: readonly string[];
+  variants: readonly string[];
+  defaultVariant: string;
+  perTokenBaseUrlTemplate: string;
+  /** "live" once substrate bytes published; "pending" until M-1+M-2+M-3 land */
+  substrateStatus: "pending" | "live";
+  /** Optional human-readable note about substrate state (timing, blockers) */
+  substrateNotes?: string;
+}
+
+/**
+ * Mibera Shadow Traits (MST) collection — collection-level metadata + sticker
+ * config. Per-token data is COMPOSED at lookup time from `tokenId` + the
+ * `perTokenBaseUrlTemplate` (no per-token records exist for MST since each
+ * token is dynamically minted via user-submitted trait strings hashed
+ * keccak256 on-chain — see `_codex/data/shadow-traits.md`).
+ */
+export interface MstCollection {
+  contract: string;
+  chain: string;
+  chainId: number;
+  standard: string;
+  tokenSymbol: "MST";
+  name: string;
+  totalSupplyKnown: number;
+  narrativeRef: string;
+  metadata: {
+    sovereignTokenURITemplate: string;
+    shippedAt: string;
+    cycle: string;
+  };
+  stickers: StickerCatalog;
+  urlContractRef: {
+    version: string;
+    schemaUrl: string;
+    migrationPhaseId: string;
+  };
+}
+
+/**
+ * Per-token MST entry returned by `lookupMst(tokenId)`. Composes the
+ * collection-level data with per-token URL resolution. Agents calling this
+ * get everything they need to render a token (sovereign metadata URL +
+ * sticker URLs per expression) without composing strings themselves.
+ */
+export interface MstEntry {
+  type: "mst";
+  ref: string;
+  tokenId: number;
+  collection: {
+    contract: string;
+    chain: string;
+    standard: string;
+    name: string;
+    symbol: "MST";
+  };
+  metadata: {
+    sovereignUrl: string;
+  };
+  stickers: {
+    manifestUrl: string;
+    version: string;
+    expressionsAvailable: readonly string[];
+    variants: readonly string[];
+    defaultVariant: string;
+    /** expression slug → URL (composed from perTokenBaseUrlTemplate) */
+    urls: Record<string, string>;
+    substrateStatus: "pending" | "live";
+    substrateNotes?: string;
+  };
+}
 
 export interface ValidateResult {
   canonical: boolean;

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -5,6 +5,7 @@ import { getArchetypeNames } from "./lookups/archetype.js";
 import { getFactorIds } from "./lookups/factor.js";
 import { getGrailNames } from "./lookups/grail.js";
 import { getMiberaIds } from "./lookups/mibera.js";
+import { getMstCollection } from "./lookups/mst.js";
 import type { ValidateResult, WorldElementType } from "./types.js";
 
 const FUZZY_THRESHOLD: Record<WorldElementType, number> = {
@@ -13,6 +14,7 @@ const FUZZY_THRESHOLD: Record<WorldElementType, number> = {
   factor: 4,
   grail: 4,
   mibera: 0,
+  mst: 0,
 };
 
 export function validateWorldElement(
@@ -39,6 +41,19 @@ export function validateWorldElement(
     case "mibera": {
       const id = Number(trimmed);
       if (Number.isInteger(id) && getMiberaIds().includes(id)) {
+        return { canonical: true, type };
+      }
+      logCoverageGap(type, trimmed, null, null, consumerHint);
+      return { canonical: false, type };
+    }
+    case "mst": {
+      // MST tokens are user-minted via trait-string keccak256 hashing — no
+      // curated id list. Treat in-range numeric tokenIds as canonical
+      // (heuristic; for definitive existence call on-chain tokenURI).
+      const stripped = trimmed.startsWith("@mst") ? trimmed.slice(4) : trimmed;
+      const id = Number(stripped);
+      const c = getMstCollection();
+      if (Number.isInteger(id) && id >= 1 && id <= c.totalSupplyKnown) {
         return { canonical: true, type };
       }
       logCoverageGap(type, trimmed, null, null, consumerHint);

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -15,6 +15,7 @@ const FUZZY_THRESHOLD: Record<WorldElementType, number> = {
   grail: 4,
   mibera: 0,
   mst: 0,
+  shadow: 0,
 };
 
 export function validateWorldElement(
@@ -46,11 +47,17 @@ export function validateWorldElement(
       logCoverageGap(type, trimmed, null, null, consumerHint);
       return { canonical: false, type };
     }
-    case "mst": {
+    case "mst":
+    case "shadow": {
       // MST tokens are user-minted via trait-string keccak256 hashing — no
       // curated id list. Treat in-range numeric tokenIds as canonical
       // (heuristic; for definitive existence call on-chain tokenURI).
-      const stripped = trimmed.startsWith("@mst") ? trimmed.slice(4) : trimmed;
+      // Shadow ≡ MST alias per _codex/data/shadow-traits.md.
+      const stripped = trimmed.startsWith("@mst")
+        ? trimmed.slice(4)
+        : trimmed.startsWith("@shadow")
+          ? trimmed.slice(7)
+          : trimmed;
       const id = Number(stripped);
       const c = getMstCollection();
       if (Number.isInteger(id) && id >= 1 && id <= c.totalSupplyKnown) {


### PR DESCRIPTION
gm @gumibera 👋 — distribution-side draft for MST sticker substrate integration. Closes the lore-keeper / distribution-operator split: my job is the lookup verb shape + URL composition + MCP tool surface; lore stayed yours (and got it right by reading the construct).

Composes with [freeside-storage#6](https://github.com/0xHoneyJar/freeside-storage/pull/6) (URL_CONTRACT v1.2.0). Extends the codex-as-authority pattern from #60.

## what this ships

```bash
micodex lookup mst 123                  # MST per-token enrichment
micodex lookup mst @mst123              # ref form
micodex lookup shadow 123               # alias — same data, @shadow<N> ref form
micodex lookup shadow @shadow42         # both refs accepted on both verbs
```

returns:

| field | shape | source |
|---|---|---|
| `collection` | contract / chain / standard / name / symbol | `_codex/data/mst-collection.json` |
| `metadata.sovereignUrl` | `metadata.0xhoneyjar.xyz/mibera/mst/{N}` | LIVE post-Cutover B 2026-05-01 |
| `stickers.urls[expr]` | per-expression sticker URL × **15 expressions** | composed from URL_CONTRACT v1.2.0 v2 paths |
| `stickers.substrateStatus` | `"pending"` until M-1+M-2 land | flips to `"live"` post-substrate (1-line diff) |

cross-transport parity preserved: same verb works on CLI · MCP stdio · MCP HTTP. agents calling this get everything they need to render or refer to a token without composing strings themselves.

## ✅ both open questions answered from the construct itself

### Q1 — Shadow vs MST: ALIAS (per `_codex/data/shadow-traits.md`)

MST = "Mibera Shadow Traits" (on-chain symbol = MST, narrative name = Shadow). Same tokens, same contract `0x048327A187b944ddac61c6e202BfccD20d17c008`. URL_CONTRACT v1.2.0 registers BOTH path conventions for transitional consumer compat.

→ Implemented `lookupShadow(tokenId)` as alias delegating to `lookupMst`. Returns identical envelope with `@shadow<N>` ref form (preserves input vocabulary). `type` stays `"mst"` (technical truth). Both refs accepted on both verbs.

### Q2 — Expression catalog: CANONICAL v2 / 15 expressions (sourced from live + dimensions)

Live canon Mibera manifest at `assets.0xhoneyjar.xyz/Mibera/expressions/current.json` reports `version: "v2"`, `expressionCount: 15`, `variants: ["transparent", "bg"]`, `defaultVariant: "transparent"`. Slugs extracted from `mibera-dimensions/lib/emoji/expression-presets.ts` `EXPRESSION_PRESETS` constant — 15 entries matching the live count exactly:

```
neutral · angry · aww · sad · uneasy · yay · smirk · worried ·
shocked · devious · tearful · grumpy · bashful · fierce · bliss
```

The `V06X_EXPRESSIONS` hardcode in `@freeside-storage/stickers/adapter.ts` (7 entries) is OUT OF DATE — used only as synthesizer shim baseline for tokens missing per-token manifests.

→ `mst-collection.json` updated: `version` → `v2`, `expressionsAvailable` → canonical 15, `variants` → `["transparent", "bg"]`, `defaultVariant` unchanged. Substrate notes document the canon mirror.

## why MST is structurally different from canon Mibera

per `_codex/data/shadow-traits.md`: MST is dynamically minted via user-submitted trait strings hashed `keccak256` on-chain (3219 known minted as of 2026-05-01). there's no per-token curated record possible — each token is whatever the user submitted. so the codex publishes COLLECTION-level metadata + URL templates; `lookupMst(tokenId)` composes URLs at call time.

contrast: canon Mibera has 10K curated tokens with per-token JSONL (`miberas.jsonl`). MST has 1 collection record + a URL composer.

## files touched (3 commits on branch)

| file | what |
|---|---|
| `_codex/data/mst-collection.json` | v2 catalog · 15 expressions · 2 variants · alias documentation in substrateNotes |
| `src/lookups/mst.ts` | `lookupMst(tokenId)` · `lookupShadow(tokenId)` (alias) · `getMstCollection()` · `resetMstCache()` |
| `src/types.ts` | `MstEntry` · `MstCollection` · `StickerCatalog` (forward-compat for Tarot/Candies/GIF/Fractures sticker substrate) · `WorldElementType` extends with `"mst"` + `"shadow"` |
| `src/validate.ts` | `validate_world_element` shared switch arm for `mst` + `shadow` (in-range numeric heuristic) |
| `src/server.ts` | `lookup_mst` MCP tool + `lookup_shadow` alias tool (description names alias rationale + 15-expression catalog) |
| `bin/micodex.ts` | CLI dispatch cases `mst` + `shadow` · help text updates · accepts `@mst<N>` and `@shadow<N>` refs on both verbs |

## what's deliberately NOT in this PR

- **`skills/query-entity/SKILL.md` updates** — initial commit added `micodex lookup mst` to patterns + new MST section. Reverted on push (commit `0fa5053ce`) per maintainer-authority signal. SKILL.md teaching content is yours; agents will discover the verbs via `micodex lookup --help` + MCP tool descriptions without it.
- **substrate bytes** — M-1 (S3 bucket policy) + M-2 (sticker generation pipeline) — operator-driven, post-merge

## smoke verified

```bash
$ micodex lookup mst 123           # → enriched envelope, 15 sticker URLs at v2 paths
$ micodex lookup shadow 42         # → same data, @shadow42 ref
$ micodex lookup mst @shadow99     # → cross-ref accepted, returns @mst99
$ micodex lookup mst 99999         # → exit 1 not_found (out of supply range)
$ pnpm build                       # → tsc clean
$ curl -sS https://assets.0xhoneyjar.xyz/Mibera/expressions/current.json | jq .expressionCount
15                                  # → matches our `expressionsAvailable.length`
$ curl -sI https://assets.0xhoneyjar.xyz/Mibera/MST/expressions/current.json
HTTP/2 403                          # → expected, M-1+M-2 substrate pending
```

## what's NOT in this PR (operator-side, post-merge)

- M-1 substrate bytes: S3 bucket policy on `Mibera/MST/*` + `Mibera/Shadow/*` — admin AWS profile (operator)
- M-2 sticker generation pipeline (operator decision: source layers · per-trait composition vs canon-mirror)
- M-3 manifest publish: builder script ready in [freeside-storage#6](https://github.com/0xHoneyJar/freeside-storage/pull/6), executes after M-1
- M-5 verification: post-substrate

substrate going live = flip `mst-collection.json` `stickers.substrateStatus` from `"pending"` → `"live"` + remove `substrateNotes`. one-line diff post-substrate.

## related

- 📐 [freeside-storage#6](https://github.com/0xHoneyJar/freeside-storage/pull/6) — URL_CONTRACT v1.2.0 + M-3 manifest builder script
- 📜 substrate handoff brief at `bonfire/grimoires/bonfire/agenda/2026-05-02-mibera-family-sticker-substrate-handoff.md`
- 🪙 [#60](https://github.com/0xHoneyJar/construct-mibera-codex/pull/60) — grail metadata authority pattern (the move I extended here)
- 🏛 [#54](https://github.com/0xHoneyJar/construct-mibera-codex/issues/54) — v1.0/v1.1 baseline lineage
- 🤖 [#53](https://github.com/0xHoneyJar/construct-mibera-codex/issues/53) — codex-mcp RFC (downstream consumer)
- 📚 [micodex-as-knowledge-map doctrine](~/vault/wiki/concepts/micodex-as-knowledge-map.md) — agents navigate via well-named verbs; `lookup_mst` + `lookup_shadow` join the verb roster

🤖 Generated with [Claude Code](https://claude.com/claude-code)