### PR TITLE
fix(docker): bundle qmd binary + prebuilt codex index for search_codex runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,15 @@ RUN pnpm install --frozen-lockfile
 # construct-surface-decision-tree.md §6.3 — searchCodex (intent layer) shells
 # out to `qmd query ...` via spawnSync at runtime. Postinstall (which clones
 # llama.cpp to build node-llama-cpp from source) reuses the build toolchain
-# installed above.
-RUN npm install -g @tobilu/qmd@^2.1.0
+# installed above. Pinned exact version (bridgebuilder #70 F2 reproducibility)
+# instead of ^2.1.0 caret range — bump intentionally.
+RUN npm install -g @tobilu/qmd@2.1.0
+
+# UID-portable qmd cache location (bridgebuilder #70 F4 root-cache-path).
+# Default ~/.cache/qmd assumes runtime user has $HOME=/root; setting
+# XDG_CACHE_HOME makes the index location explicit and survives non-root
+# `USER` directives, Kubernetes runAsNonRoot, or `docker run -u <uid>`.
+ENV XDG_CACHE_HOME=/opt/qmd-cache
 
 COPY . .
 RUN pnpm run build
@@ -30,7 +37,7 @@ RUN pnpm run build
 # Pre-build the qmd codex collections (codex-grails + codex-core-lore) in the
 # image. Without this step, search_codex returns "qmd_unavailable" at runtime
 # even though the binary is on PATH — the qmd index is what makes search work.
-# Lands at /root/.cache/qmd/index.sqlite (qmd's default cache location).
+# Lands at /opt/qmd-cache/qmd/ (XDG_CACHE_HOME set above) so it's UID-portable.
 RUN bash scripts/build-micodex-index.sh
 
 FROM node:20-slim
@@ -47,15 +54,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # qmd: copy the global package (where the JS + node-llama-cpp .node binary live)
-# + the bin script + the prebuilt codex index. searchCodex (src/lookups/search.ts:120)
-# spawnSync's `qmd` from PATH at runtime; the .node addon dlopens
-# libstdc++/libgomp installed above. Without these COPY+chmod, search_codex
-# returns "qmd_unavailable" at first call — the silent-runtime-failure pattern
-# from PR #69 reaching one layer deeper.
+# + symlink the bin (preserves __dirname-relative require resolution per
+# bridgebuilder #70 F1) + copy the prebuilt index. searchCodex
+# (src/lookups/search.ts:120) spawnSync's `qmd` from PATH at runtime;
+# the .node addon dlopens libstdc++/libgomp installed above. XDG_CACHE_HOME
+# duplicated here so qmd at runtime finds the index at the same explicit path.
 COPY --from=builder /usr/local/lib/node_modules/@tobilu /usr/local/lib/node_modules/@tobilu
-COPY --from=builder /usr/local/lib/node_modules/@tobilu/qmd/bin/qmd /usr/local/bin/qmd
-RUN chmod +x /usr/local/bin/qmd
-COPY --from=builder /root/.cache/qmd /root/.cache/qmd
+RUN ln -s /usr/local/lib/node_modules/@tobilu/qmd/bin/qmd /usr/local/bin/qmd
+ENV XDG_CACHE_HOME=/opt/qmd-cache
+COPY --from=builder /opt/qmd-cache /opt/qmd-cache
+RUN chmod -R a+r /opt/qmd-cache
+
+# Smoke-test the qmd binary at build time (bridgebuilder #70 F5). Catches:
+# - bin symlink resolution failure
+# - missing libstdc++/libgomp dependencies
+# - corrupted/missing index from XDG_CACHE_HOME mismatch
+# Build fails loudly here instead of search_codex returning errors at first call.
+RUN qmd --version && qmd status | head -5
 
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,22 @@ RUN corepack enable && corepack prepare pnpm@8.15.9 --activate
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
+# qmd: installed globally so the binary is on PATH for build-micodex-index.sh
+# (next step) and copyable to the runtime stage. peerDependency per
+# construct-surface-decision-tree.md §6.3 — searchCodex (intent layer) shells
+# out to `qmd query ...` via spawnSync at runtime. Postinstall (which clones
+# llama.cpp to build node-llama-cpp from source) reuses the build toolchain
+# installed above.
+RUN npm install -g @tobilu/qmd@^2.1.0
+
 COPY . .
 RUN pnpm run build
+
+# Pre-build the qmd codex collections (codex-grails + codex-core-lore) in the
+# image. Without this step, search_codex returns "qmd_unavailable" at runtime
+# even though the binary is on PATH — the qmd index is what makes search work.
+# Lands at /root/.cache/qmd/index.sqlite (qmd's default cache location).
+RUN bash scripts/build-micodex-index.sh
 
 FROM node:20-slim
 WORKDIR /app
@@ -31,6 +45,17 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libstdc++6 libgomp1 ca-certificates \
   && rm -rf /var/lib/apt/lists/*
+
+# qmd: copy the global package (where the JS + node-llama-cpp .node binary live)
+# + the bin script + the prebuilt codex index. searchCodex (src/lookups/search.ts:120)
+# spawnSync's `qmd` from PATH at runtime; the .node addon dlopens
+# libstdc++/libgomp installed above. Without these COPY+chmod, search_codex
+# returns "qmd_unavailable" at first call — the silent-runtime-failure pattern
+# from PR #69 reaching one layer deeper.
+COPY --from=builder /usr/local/lib/node_modules/@tobilu /usr/local/lib/node_modules/@tobilu
+COPY --from=builder /usr/local/lib/node_modules/@tobilu/qmd/bin/qmd /usr/local/bin/qmd
+RUN chmod +x /usr/local/bin/qmd
+COPY --from=builder /root/.cache/qmd /root/.cache/qmd
 
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
## Summary

Post-#69 verification surfaced a deeper layer of the same KRANZ-act-1 reproducibility issue: the codex MCP at v1.4.0 now registers `search_codex` (per PR #65), but calling it returns:

```
{
  "error": "qmd_unavailable",
  "message": "qmd binary not found in PATH",
  "hint": "@tobilu/qmd is a peerDependency. install + run scripts/build-micodex-index.sh"
}
```

PR #69 fixed the **build** (alpine→slim · runtime libs). This PR fixes the **runtime** (qmd binary + prebuilt qmd index in the image).

## What changes

**Builder stage** (after `pnpm install`):
- `npm install -g @tobilu/qmd@^2.1.0` — postinstall reuses the build toolchain (git/make/python3/g++) already added in #69
- `bash scripts/build-micodex-index.sh` — populates `~/.cache/qmd/index.sqlite` with codex-grails + codex-core-lore collections + context

**Runtime stage** (after libs install):
- `COPY` qmd's global node_modules (package JS + `.node` addon)
- Explicit file-copy of qmd bin script (not relying on Docker symlink-resolution behavior)
- `chmod +x` the bin
- `COPY` the prebuilt `~/.cache/qmd` index

Runtime stage stays compiler-free (#69 F5 PRAISE preserved) — only adds qmd's compiled artifacts + index, no build tools.

## Verifies post-merge

- [ ] Railway auto-builds successfully (no postinstall regression)
- [ ] `curl -X POST https://mcp.0xhoneyjar.xyz/codex/mcp ... tools/call name:"search_codex" arguments:{intent:"void motif"}` → returns `@g876` Black Hole at score ≥0.7 (today: returns `qmd_unavailable`)
- [ ] WITNESS S3 in `grimoires/loa/qa/qa-cycle-micodex-09a-2026-05-02.md` (PR #68): all 5 substrate-truth seed cases pass against prod
- [ ] 9/9 tools functional in production (today: 8/9 — `lookup_*` work, `search_codex` broken)

## Image-size cost

- `+~50MB` for global qmd package install
- `+~90MB` for qmd `index.sqlite` (43 grails + core-lore content + embeddings)

Acceptable trade for a working intent layer in prod. If image size becomes a concern, V2 candidate: lazy-build the index on container start (saves image bytes, costs ~30-90s cold start).

## Related

- #69 — Dockerfile alpine→slim (merged)
- #68 — eval corpus (gates on this for live S3 verification)
- 0xHoneyJar/freeside-characters#20 — WITNESS QA dogfood checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)