### PR TITLE
fix(docker): copy qmd registry (~/.config/qmd) — search_codex still failed post-#70

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,15 +80,19 @@ RUN ln -s /usr/local/lib/node_modules/@tobilu/qmd/bin/qmd /usr/local/bin/qmd
 COPY --from=builder /root/.config/qmd /root/.config/qmd
 COPY --from=builder /root/.cache/qmd /root/.cache/qmd
 
-# Smoke-test the qmd binary AND its access to the prebuilt index at build time
-# (bridgebuilder #70 F5 + this PR's tighter check). Catches:
+# Smoke-test qmd binary + assert BOTH expected collections register at build time
+# (bridgebuilder #70 F5 + #71 F2 tighter assertion). Catches:
 # - bin symlink resolution failure
 # - missing libstdc++/libgomp dependencies
-# - registry/cache mismatch (the exact failure mode #70 hit on first deploy)
-# `qmd status` loads the registry; if collections list is empty here, the COPY
-# missed the registry. Build fails loudly instead of search_codex erroring at
-# first call.
-RUN qmd --version && qmd status
+# - registry/cache mismatch (exact failure mode #70 hit on first deploy)
+# - either codex collection failing to register
+# Asserts on collection NAMES not just `qmd status` exit code — the bug we
+# shipped in #70 had qmd status returning 0 but search_codex still erroring
+# because the registry was empty.
+RUN qmd --version \
+  && qmd status \
+  && qmd status | grep -q "codex-grails" \
+  && qmd status | grep -q "codex-core-lore"
 
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,19 +25,29 @@ RUN pnpm install --frozen-lockfile
 # instead of ^2.1.0 caret range — bump intentionally.
 RUN npm install -g @tobilu/qmd@2.1.0
 
-# UID-portable qmd cache location (bridgebuilder #70 F4 root-cache-path).
-# Default ~/.cache/qmd assumes runtime user has $HOME=/root; setting
-# XDG_CACHE_HOME makes the index location explicit and survives non-root
-# `USER` directives, Kubernetes runAsNonRoot, or `docker run -u <uid>`.
-ENV XDG_CACHE_HOME=/opt/qmd-cache
-
 COPY . .
 RUN pnpm run build
 
 # Pre-build the qmd codex collections (codex-grails + codex-core-lore) in the
 # image. Without this step, search_codex returns "qmd_unavailable" at runtime
 # even though the binary is on PATH — the qmd index is what makes search work.
-# Lands at /opt/qmd-cache/qmd/ (XDG_CACHE_HOME set above) so it's UID-portable.
+#
+# qmd splits state across THREE locations (verified via local install + qmd source
+# inspection 2026-05-02 post #70 deploy failure):
+#   - ~/.config/qmd/index.yml      collection registry (XDG-config)
+#   - ~/.cache/qmd/index.sqlite    content + embeddings (XDG-cache)
+#   - ~/.cache/qmd/models/         embedding model files (HARDCODED homedir/.cache,
+#                                    NOT XDG-respecting per dist/llm.js:64)
+#
+# Earlier #70 attempted XDG_CACHE_HOME=/opt/qmd-cache for non-root portability,
+# but that surfaced two bugs: (1) only redirects ~/.cache, not the registry at
+# ~/.config; (2) doesn't redirect the model cache path. Net: runtime returned
+# "qmd collection codex-grails not found" because the registry yaml was missing.
+#
+# Pragmatic fix: don't rebase qmd's paths. Let it write defaults (~/.config +
+# ~/.cache) in builder, then COPY both directories verbatim to runtime. The
+# bridgebuilder #70 F4 non-root portability concern was theoretical — Railway
+# runs as root by default; if non-root deploy is ever needed, address then.
 RUN bash scripts/build-micodex-index.sh
 
 FROM node:20-slim
@@ -55,22 +65,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # qmd: copy the global package (where the JS + node-llama-cpp .node binary live)
 # + symlink the bin (preserves __dirname-relative require resolution per
-# bridgebuilder #70 F1) + copy the prebuilt index. searchCodex
-# (src/lookups/search.ts:120) spawnSync's `qmd` from PATH at runtime;
-# the .node addon dlopens libstdc++/libgomp installed above. XDG_CACHE_HOME
-# duplicated here so qmd at runtime finds the index at the same explicit path.
+# bridgebuilder #70 F1) + copy BOTH state directories at the default paths.
+# searchCodex (src/lookups/search.ts:120) spawnSync's `qmd` from PATH at runtime;
+# the .node addon dlopens libstdc++/libgomp installed above.
+#
+# qmd state split (see builder comment above):
+#   /root/.config/qmd/   collection registry — REQUIRED, missed in #70
+#   /root/.cache/qmd/    content + embeddings + models — REQUIRED for query
+#
+# Image-size cost: ~/.cache/qmd holds embedding model (~50-150MB depending on model).
+# That's the trade for working search_codex without runtime model download.
 COPY --from=builder /usr/local/lib/node_modules/@tobilu /usr/local/lib/node_modules/@tobilu
 RUN ln -s /usr/local/lib/node_modules/@tobilu/qmd/bin/qmd /usr/local/bin/qmd
-ENV XDG_CACHE_HOME=/opt/qmd-cache
-COPY --from=builder /opt/qmd-cache /opt/qmd-cache
-RUN chmod -R a+r /opt/qmd-cache
+COPY --from=builder /root/.config/qmd /root/.config/qmd
+COPY --from=builder /root/.cache/qmd /root/.cache/qmd
 
-# Smoke-test the qmd binary at build time (bridgebuilder #70 F5). Catches:
+# Smoke-test the qmd binary AND its access to the prebuilt index at build time
+# (bridgebuilder #70 F5 + this PR's tighter check). Catches:
 # - bin symlink resolution failure
 # - missing libstdc++/libgomp dependencies
-# - corrupted/missing index from XDG_CACHE_HOME mismatch
-# Build fails loudly here instead of search_codex returning errors at first call.
-RUN qmd --version && qmd status | head -5
+# - registry/cache mismatch (the exact failure mode #70 hit on first deploy)
+# `qmd status` loads the registry; if collections list is empty here, the COPY
+# missed the registry. Build fails loudly instead of search_codex erroring at
+# first call.
+RUN qmd --version && qmd status
 
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
## Summary

Post-#70 verification (Railway redeploy 2026-05-02T~23:55Z): search_codex returned a NEW error — `"qmd collection \"codex-grails\" not found."`. The build worked, qmd binary loads, but qmd's **collection registry** is missing in runtime.

## Root cause

qmd splits state across **three** locations (verified via local install + qmd source inspection):

| location | purpose | XDG-respecting? |
|---|---|---|
| `~/.config/qmd/index.yml` | collection registry (yaml) | ✅ XDG_CONFIG_HOME (default `~/.config`) |
| `~/.cache/qmd/index.sqlite` | content + embeddings | ✅ XDG_CACHE_HOME |
| `~/.cache/qmd/models/` | embedding model files | ❌ HARDCODED `homedir()/.cache/qmd/models` per `dist/llm.js:64` |

PR #70 set `XDG_CACHE_HOME=/opt/qmd-cache` for non-root portability per bridgebuilder F4. But that only redirects `~/.cache`, not `~/.config`. So:

1. Builder wrote registry to `/root/.config/qmd/index.yml` (always defaults here, regardless of XDG_CACHE_HOME)
2. Builder wrote sqlite + models to `/opt/qmd-cache/qmd/` (XDG redirect)
3. Runtime COPYed only `/opt/qmd-cache` → registry was MISSING in runtime
4. qmd at runtime: "I have a sqlite file but don't know what collections exist"
5. Result: `qmd collection codex-grails not found`

## Fix

Pragmatic: **don't rebase qmd's paths**. Drop `XDG_CACHE_HOME` ENV; let qmd write defaults in builder; COPY both `/root/.config/qmd` + `/root/.cache/qmd` verbatim to runtime.

The non-root portability concern from #70 F4 was theoretical — Railway runs as root by default. If non-root deploy is ever needed, address then with a proper qmd config-path override (qmd 2.x doesn't expose one for `~/.config`).

## Tightened smoke

`RUN qmd --version && qmd status` (no `head` pipe) — `qmd status` loads the registry, so if the COPY missed something the collections list will be empty and we can fail the build loudly instead of search_codex erroring at first call.

## Image-size cost

`+ ~/.cache/qmd/models` (~50-150MB depending on embedding model qmd downloaded). Trade for working `search_codex` without runtime model download. V2 candidate: lazy model load + persistent volume mount.

## Verifies post-merge

- [ ] Railway auto-builds successfully
- [ ] `curl -X POST https://mcp.0xhoneyjar.xyz/codex/mcp ... tools/call name:"search_codex" arguments:{intent:"void motif"}` → returns `@g876` Black Hole at score ≥0.7 (today: returns "qmd collection codex-grails not found")
- [ ] WITNESS S3 (5 substrate-truth seed cases) all pass against prod
- [ ] WITNESS SC1-SC3 narrative scenarios become runnable

## Related

- #69 — Dockerfile alpine→slim (merged)
- #70 — qmd binary bundling + index build (merged but caused this bug via XDG-only-half redirect)
- #68 — eval corpus + WITNESS QA (gates on this for live S3 verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)