### PR TITLE
feat(vm): add 5 new vending machine traits

### DIFF
--- a/vending-machine/README.md
+++ b/vending-machine/README.md
@@ -8,7 +8,7 @@ The Mibera Shadows Vending Machine mints custom trait combinations as ERC-721 to
 
 The Vending Machine is one of the primary ways the **community can affect the fabric of Mibera**. Many of these traits originated as community suggestions, making this collection a living record of collective creative input.
 
-This page catalogs the **102 exclusive traits** (across 11 categories, excludes overlays) that exist only in the Vending Machine and are not part of the main collection's 1,337 generative traits.
+This page catalogs the **107 exclusive traits** (across 11 categories, excludes overlays) that exist only in the Vending Machine and are not part of the main collection's 1,337 generative traits.
 
 ## Contract
 
@@ -25,11 +25,11 @@ This page catalogs the **102 exclusive traits** (across 11 categories, excludes 
 | [Face Accessories](face-accessories/README.md) | 1 | |
 | [Glasses](glasses/README.md) | 4 | |
 | [Hats](hats/README.md) | 19 | |
-| [Items](items/README.md) | 21 | |
+| [Items](items/README.md) | 24 | |
 | [Masks](masks/README.md) | 5 | |
 | [Mouth](mouth/README.md) | 3 | |
 | [Necklaces](necklaces/README.md) | 19 | VM-exclusive category |
-| [Shirts](shirts/README.md) | 17 | |
+| [Shirts](shirts/README.md) | 19 | |
 | [Tattoos](tattoos/README.md) | 1 | |
 | Overlays | — | *Coming soon* |
 

--- a/vending-machine/items/README.md
+++ b/vending-machine/items/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-## All Entries (21)
+## All Entries (24)
 
 - [Carpenter's Plane](carpenters-plane.md)
 - [SNL Photo](snl-photo.md)
@@ -27,6 +27,9 @@
 - [One Eyed Bear Plush](one-eyed-bear-plush.md)
 - [Cancer Crab](cancer-crab.md)
 - [Shuriken](shuriken.md)
+- [Fatira](fatira.md)
+- [Swishers Green](swishers-green.md)
+- [Swishers Purple](swishers-purple.md)
 
 ---
 

--- a/vending-machine/items/fatira.md
+++ b/vending-machine/items/fatira.md
@@ -1,0 +1,25 @@
+---
+name: "Fatira"
+category: items
+from: "Gumi"
+image: "https://assets.0xhoneyjar.xyz/Mibera/traits/fatira.webp"
+---
+
+<div align="center">
+  <img src="https://assets.0xhoneyjar.xyz/Mibera/traits/fatira.webp" alt="Fatira" width="320" />
+</div>
+
+
+# Fatira
+
+## Description
+
+A popular Ethiopian street food — an egg-filled flatbread drizzled with a generous amount of honey. A nod to the Ethiopian ancestor lineage in the collection.
+
+## From
+
+Gumi
+
+---
+
+*VM-exclusive trait · [All VM Traits](../README.md) · [Items](README.md)*

--- a/vending-machine/items/swishers-green.md
+++ b/vending-machine/items/swishers-green.md
@@ -1,0 +1,25 @@
+---
+name: "Swishers Green"
+category: items
+from: "Gumi"
+image: "https://assets.0xhoneyjar.xyz/Mibera/traits/swishers%20green.webp"
+---
+
+<div align="center">
+  <img src="https://assets.0xhoneyjar.xyz/Mibera/traits/swishers%20green.webp" alt="Swishers Green" width="320" />
+</div>
+
+
+# Swishers Green
+
+## Description
+
+A pack of unopened Swisher Sweets. Typically used by dumping the tobacco and using the wrap to roll a blunt.
+
+## From
+
+Gumi
+
+---
+
+*VM-exclusive trait · [All VM Traits](../README.md) · [Items](README.md)*

--- a/vending-machine/items/swishers-purple.md
+++ b/vending-machine/items/swishers-purple.md
@@ -1,0 +1,25 @@
+---
+name: "Swishers Purple"
+category: items
+from: "Gumi"
+image: "https://assets.0xhoneyjar.xyz/Mibera/traits/swishers%20purple.webp"
+---
+
+<div align="center">
+  <img src="https://assets.0xhoneyjar.xyz/Mibera/traits/swishers%20purple.webp" alt="Swishers Purple" width="320" />
+</div>
+
+
+# Swishers Purple
+
+## Description
+
+A pack of unopened Swisher Sweets. Typically used by dumping the tobacco and using the wrap to roll a blunt.
+
+## From
+
+Gumi
+
+---
+
+*VM-exclusive trait · [All VM Traits](../README.md) · [Items](README.md)*

--- a/vending-machine/shirts/README.md
+++ b/vending-machine/shirts/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-## All Entries (17)
+## All Entries (19)
 
 - [Beras Jersey](beras-jersey.md)
 - [Chaos Hunters](chaos-hunters.md)
@@ -23,6 +23,8 @@
 - [Nun Outfit](nun-outfit.md)
 - [El Salvador Soccer](el-salvador-soccer.md)
 - [Red Floral Shirt](red-floral-shirt.md)
+- [Ancient Mibera](ancient-mibera.md)
+- [Black Shirt With White Lettering](black-shirt-with-white-lettering.md)
 
 ---
 

--- a/vending-machine/shirts/ancient-mibera.md
+++ b/vending-machine/shirts/ancient-mibera.md
@@ -1,0 +1,25 @@
+---
+name: "Ancient Mibera"
+category: shirts
+from: "Gumi"
+image: "https://assets.0xhoneyjar.xyz/Mibera/traits/ancient%20mibera.webp"
+---
+
+<div align="center">
+  <img src="https://assets.0xhoneyjar.xyz/Mibera/traits/ancient%20mibera.webp" alt="Ancient Mibera" width="320" />
+</div>
+
+
+# Ancient Mibera
+
+## Description
+
+A shirt that bears the logo of the Ancient Mibera validator.
+
+## From
+
+Gumi
+
+---
+
+*VM-exclusive trait · [All VM Traits](../README.md) · [Shirts](README.md)*

--- a/vending-machine/shirts/black-shirt-with-white-lettering.md
+++ b/vending-machine/shirts/black-shirt-with-white-lettering.md
@@ -1,0 +1,25 @@
+---
+name: "Black Shirt With White Lettering"
+category: shirts
+from: ""
+image: "https://assets.0xhoneyjar.xyz/Mibera/traits/black%20shirt%20with%20white%20lettering.webp"
+---
+
+<div align="center">
+  <img src="https://assets.0xhoneyjar.xyz/Mibera/traits/black%20shirt%20with%20white%20lettering.webp" alt="Black Shirt With White Lettering" width="320" />
+</div>
+
+
+# Black Shirt With White Lettering
+
+## Description
+
+*WIP*
+
+## From
+
+*Community attribution TBD*
+
+---
+
+*VM-exclusive trait · [All VM Traits](../README.md) · [Shirts](README.md)*


### PR DESCRIPTION
## Summary
- **2 new shirts**: Ancient Mibera, Black Shirt With White Lettering
- **3 new items**: Fatira, Swishers Green, Swishers Purple
- Images assembled via `micodex-assembler.py` and uploaded to S3
- Category READMEs and main VM README counts updated (102 → 107)

## Test plan
- [ ] Verify S3 images render on GitHub preview
- [ ] Confirm trait counts in READMEs are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)