### PR TITLE
fix(readme): repair mangled links, drop old-issue refs, refresh VM status

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The 10,000 Miberas and their temporal identities.
 - [MiParcels](miparcels/README.md) — 10,000 sealed envelopes from Phase 1 reveal
 - [Birthdays](birthdays/README.md) — 9,995 unique birthdays spanning 15,000 years
 - [Fractures](fractures/README.md) — 10 reveal phases from sealed envelope to final form
+- [Mibera Sets](mibera-sets/README.md) — 12 Honey Road ERC-1155 tokens on Optimism
 
 ### VI. The Mechanics
 - [Ranking & Scoring](traits/overlays/ranking/README.md) — Swag Score and tribal coherence
@@ -57,7 +58,7 @@ The 10,000 Miberas and their temporal identities.
 ### VII. The Ecosystem
 Partners and collaborations.
 - [Special Collections](special-collections/README.md) — Berachain ecosystem integrations
-- [Vending Machine](vending-machine/README.md) — VM-exclusive Shadow Traits (update in progress)
+- [Vending Machine](vending-machine/README.md) — 108 VM-exclusive Shadow Traits across 11 categories
 
 ### VIII. Behind the Scenes
 The people and process behind the collection.
@@ -114,8 +115,6 @@ Explore the 10,000 Miberas through faceted search — filter by archetype, ances
 
 The codex ships an MCP server for narrative-bot consumers (freeside-characters' ruggy + satoshi today, future puruhani daemons). It is the **read interface** to the codex's canonical world-elements.
 
-Per [RFC #53](https://github.com/0xHoneyJarxhoneyjar/construct-mibera-codex/issues/53) and Gumi's locked v1 design (2026-04-29):
-
 | Tool | What it returns |
 |---|---|
 | `lookup_zone(slug)` | Full zone — archetype, era, essence, Lynch primitives, KANSEI tokens |
@@ -141,7 +140,7 @@ Add to Claude Code (`.claude/settings.json` or `claude_desktop_config.json`):
   "mcpServers": {
     "codex": {
       "command": "pnpm",
-      "args": ["--prefix", "/path/toxhoneyjar/construct-mibera-codex", "mcp"]
+      "args": ["--prefix", "/path/to/construct-mibera-codex", "mcp"]
     }
   }
 }
@@ -181,7 +180,7 @@ Implements `constructs-mcp-shape` + `constructs-mcp-deployment-topology` from op
 
 ## Contributing
 
-The codex is a living document. If something is wrong, missing, or could be better — [open an issue](https://github.com/0xHoneyJarxhoneyjar/construct-mibera-codex/issues/new).
+The codex is a living document. If something is wrong, missing, or could be better — [open an issue](https://github.com/0xHoneyJar/construct-mibera-codex/issues/new).
 
 Corrections, lore additions, cultural context, trait documentation, broken links, grail history, or information you think should be here but isn't — all welcome. Just describe what you're seeing and what you think it should be.
 

--- a/_codex/reports/health.md
+++ b/_codex/reports/health.md
@@ -32,7 +32,7 @@ All meta file counts match disk reality.
 
 ## Prose Count Claims
 
-All 16 prose count claims match disk reality.
+All 17 prose count claims match disk reality.
 
 ## Export Staleness
 

--- a/_codex/scripts/health-report.py
+++ b/_codex/scripts/health-report.py
@@ -210,6 +210,7 @@ PROSE_CLAIMS = [
     ("llms.txt", r"grails/\{slug\}\.md \| ([\d,]+) \|", "grail"),
     ("llms.txt", r"([\d,]+) Grails — 42 canonical", "grail"),
     ("SUMMARY.md", r"([\d,]+) exclusive traits not in the generative 10K", "vm_trait"),
+    ("README.md", r"([\d,]+) VM-exclusive Shadow Traits across 11 categories", "vm_trait"),
     ("browse/README.md", r"([\d,]+) exclusive traits available only through the Shadow Traits", "vm_trait"),
     ("browse/README.md", r"([\d,]+) hand-drawn 1/1 art pieces", "grail"),
     ("CLAUDE.md", r"VM-exclusive Shadow Traits \(11 categories\) \| ([\d,]+) \|", "vm_trait"),

--- a/_codex/scripts/reports/audit-links.json
+++ b/_codex/scripts/reports/audit-links.json
@@ -1,7 +1,7 @@
 {
-  "timestamp": "2026-06-12T15:23:58Z",
+  "timestamp": "2026-06-12T17:12:19Z",
   "files_checked": 21777,
-  "total_links": 294869,
+  "total_links": 294870,
   "broken_links": 0,
   "issues": []
 }

--- a/grails/README.md
+++ b/grails/README.md
@@ -44,7 +44,7 @@ Programmatic access:
 - **MCP** — `lookup_grail({query: "black-hole"})` → the `image` field is in the response
 - **Raw** — read the relevant line from `_codex/data/grails.jsonl`
 
-The empirical convention was discovered via [issue #62](https://github.com/0xHoneyJarxhoneyjar/construct-mibera-codex/issues/62)
+The empirical convention was discovered via [issue #62](https://github.com/0xHoneyJar/construct-mibera-codex/issues/62)
 (Adeitasuna, 2026-04-30) — 40 of 42 grails resolved on first guess; multi-word
 names (`Black Hole`, `Native American`) required ~14 HEAD probes each before
 the lowercase-hyphenated form was identified. This document closes that gap.


### PR DESCRIPTION
## What

- Fixes a bad find-and-replace artifact that inserted `xhoneyjar` into GitHub URLs (`0xHoneyJarxhoneyjar/...` → `0xHoneyJar/...`) in `README.md` and `grails/README.md`, plus the mangled `/path/toxhoneyjar/` in the MCP config example
- Removes the RFC #53 provenance line from the codex-mcp section — the README shouldn't reference old issues
- Replaces the stale "(update in progress)" note on the Vending Machine entry with the actual state: 108 VM-exclusive Shadow Traits across 11 categories
- Links `mibera-sets/` from § The Collection (previously only the on-chain data doc was linked)
- Registers the new README 108-count claim in `health-report.py` `PROSE_CLAIMS` per the drift-prevention rule

## Verification

- `health-report.py`: 100% — HEALTHY (including the new PROSE_CLAIMS pattern)
- `audit-links.sh`: ALL LINKS VALID

🤖 Generated with [Claude Code](https://claude.com/claude-code)