### PR TITLE
Point image-host doc examples at the canonical CDN

### DIFF
--- a/_codex/schema/README.md
+++ b/_codex/schema/README.md
@@ -78,7 +78,7 @@ Traits are split into subcategories with different schemas.
 ```yaml
 ---
 name: Golden Hoop
-image: "https://mibera.fsn1.your-objectstorage.com/..."
+image: "https://assets.0xhoneyjar.xyz/Mibera/traits/...webp"
 archetype: "Aligned culture, related to the 90s rave"
 swag_score: 3
 date_added: "December 9, 2024"
@@ -101,7 +101,7 @@ date_added: "December 9, 2024"
 ```yaml
 ---
 name: Beige
-image: "https://mibera.fsn1.your-objectstorage.com/..."
+image: "https://assets.0xhoneyjar.xyz/Mibera/traits/...webp"
 date_added: "August 13, 2024"
 ---
 ```

--- a/_codex/scripts/README.md
+++ b/_codex/scripts/README.md
@@ -45,7 +45,7 @@ Run from the repo root:
 | Script | Description |
 |--------|-------------|
 | `micodex-assembler.py` | Composite trait layer PNGs onto bundled template images (background, body, arms) to produce final character portraits as WebP. Requires **Pillow** and **tqdm** (`pip install Pillow tqdm`). Originally from [micodex-images](https://github.com/0xHoneyJar/micodex-images). |
-| `embed-images.py` | Map assembled `.webp` trait images to codex entries, update `image:` frontmatter and insert inline `<img>` HTML pointing at `s3://mibera/traits/`. Outputs report to `reports/image-embed-report.json`. |
+| `embed-images.py` | Map assembled `.webp` trait images to codex entries, update `image:` frontmatter and insert inline `<img>` HTML pointing at the CDN (`https://assets.0xhoneyjar.xyz/Mibera/traits/`). Outputs report to `reports/image-embed-report.json`. |
 
 ### Image Pipeline — End to End
 


### PR DESCRIPTION
Cleanup found while reviewing the codex: the data is clean (all 1,213 trait files use `assets.0xhoneyjar.xyz`), but two docs still showed origins that appear in **zero** data files.

- `_codex/schema/README.md:81,104` — trait `image:` examples used `mibera.fsn1.your-objectstorage.com` → canonical `https://assets.0xhoneyjar.xyz/Mibera/traits/...webp`.
- `_codex/scripts/README.md:48` — `embed-images.py` was described as pointing `<img>` at `s3://mibera/traits/`, which **line 75 of the same file** calls deprecated → the CDN host.

The intentional "legacy bucket is deprecated" explanations (scripts README + VM runbook) are untouched. Link audit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)