### PR TITLE
docs(archetype-quiz): document the soulbound MIRA quiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Contract addresses and ecosystem mechanics.
 - [Shadow Traits](_codex/data/shadow-traits.md) — On-chain trait uniqueness system
 - [Candies Marketplace](_codex/data/candies-mechanics.md) — Seizure mechanics and holder discounts
 - [Mibera Sets](_codex/data/mibera-sets.md) — 12-tier ERC-1155 on Optimism
-- [Archetype Quiz](_codex/data/tarot-quiz.md) — Soulbound archetype alignment
+- [Archetype Quiz](core-lore/archetype-quiz/README.md) — 7-question soulbound quiz mapping wallets to 10 esoteric archetypes ([contract mechanics](_codex/data/tarot-quiz.md))
 - [The 42 Motif](_codex/data/42-motif.md) — Numerological easter eggs across contracts
 - [Contract ABIs](_codex/data/abis/README.md) — Machine-readable contract interfaces
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -9,6 +9,7 @@
 
 ## II. The Framework
 * [Archetypes](core-lore/archetypes.md)
+* [Archetype Quiz (MIRA)](core-lore/archetype-quiz/README.md)
 * [Ancestors](core-lore/ancestors/README.md)
 
 ## III. The Mysticism

--- a/_codex/data/tarot-quiz.md
+++ b/_codex/data/tarot-quiz.md
@@ -6,7 +6,9 @@
 
 The Archetype Quiz is a soulbound NFT system on Berachain that assigns each participant an archetype. Users take an off-chain quiz (the "Tarot Quiz") that determines their archetype alignment, then mint a non-transferable token recording that result on-chain. The contract is named `MiberaArchetypeAlignment` with token name "miChainMirror" and symbol "MIRA".
 
-The contract itself does not contain quiz logic or archetype assignment — it is a pure soulbound minting contract. The quiz happens off-chain (likely via the Mibera frontend), and the resulting archetype is encoded in the token's metadata served through the `baseURI`.
+The contract itself does not contain quiz logic or archetype assignment — it is a pure soulbound minting contract. The quiz happens **off-chain** on the Mibera Honeyroad frontend, and the resulting archetype is encoded in the token's metadata served through the `baseURI`.
+
+> **The full quiz is documented** in [`core-lore/archetype-quiz/`](../../core-lore/archetype-quiz/README.md): the [7 questions and scoring engine](../../core-lore/archetype-quiz/quiz-questions.md), the [10 archetypes](../../core-lore/archetype-quiz/), and the [esoteric roles, on-chain actions, and boosts](../../core-lore/archetype-quiz/esoteric-roles.md). This file covers only the on-chain contract mechanics.
 
 ## Contract
 
@@ -51,7 +53,7 @@ Returns the token ID for a given address, or `type(uint256).max` if the address 
 
 Token metadata is served via `baseURI + tokenId`. The base URI is set by the contract owner via `setBaseURI(string)`. A `triggerBatchMetadataUpdate()` function emits `BatchMetadataUpdate(0, type(uint256).max)` to signal indexers that all token metadata has changed.
 
-<!-- GAP: The actual baseURI value and metadata JSON schema are unknown. The metadata likely encodes the quiz result (archetype assignment, tarot card, or alignment details), but the structure has not been inspected on-chain. -->
+The metadata is the **source of truth for the archetype result**. It is generated server-side from the `quiz_metadata` Postgres table (Drizzle/Railway) and served via the Honeyroad route `app/api/quiz/[tokenId]/route.ts`. Each record encodes the wallet's dominant archetype, its grid vector, and the secondary/tertiary archetypes. See [`core-lore/archetype-quiz/quiz-questions.md`](../../core-lore/archetype-quiz/quiz-questions.md) for how those values are computed.
 
 ### Owner Functions
 
@@ -67,33 +69,25 @@ Token metadata is served via `baseURI + tokenId`. The base URI is set by the con
 
 The archetype assignment happens in two layers:
 
-1. **Off-chain quiz**: Users answer questions on the Mibera frontend (the "Tarot Quiz" or "Archetype Quiz"). The quiz determines which of the four archetypes the user aligns with.
+1. **Off-chain quiz**: Users answer **7 questions** on the Mibera Honeyroad frontend (the "Tarot Quiz" / "Archetype Quiz"). Answers are tallied and projected onto a 2-axis grid, weighted by on-chain boosts, to select one of **10 quiz archetypes** — Centurion, Oracle, Witness, Prodigal Son, Doppel, Ouroboros, Anointer, Serpent, Bound One, Phoenix. The result is saved to the `quiz_metadata` Postgres table before mint. Full mechanics: [`core-lore/archetype-quiz/quiz-questions.md`](../../core-lore/archetype-quiz/quiz-questions.md).
 2. **On-chain mint**: The user calls `mint()` to create their soulbound token. The token ID is sequential and carries no on-chain archetype data — the archetype result is encoded in the off-chain metadata served at the token URI.
 
-<!-- GAP: The exact quiz questions, scoring algorithm, and how quiz results map to metadata tokenIDs are unknown. It is unclear whether the frontend enforces that a user must complete the quiz before minting, or whether any wallet can mint freely and the metadata is assigned server-side based on quiz completion records. -->
+## Two archetype systems — do not conflate
 
-<!-- GAP: It is unknown whether the quiz assigns one of the 4 primary archetypes (Freetekno, Milady, Chicago Detroit, Acidhouse) or a more granular result involving tarot cards, elements, or ancestors. The contract name "ArchetypeAlignment" and the token name "miChainMirror" suggest the result is an archetype alignment that "mirrors" the user's identity on-chain. -->
+The quiz's **10 archetypes are a separate system** from the collection's **4 trait archetypes**. They share no members and are computed differently.
 
-## Relationship to the 10 Archetypes
+| | Trait archetypes | Quiz archetypes (MIRA) |
+|---|---|---|
+| Count | 4 | 10 |
+| Members | Freetekno, Chicago/Detroit, Acidhouse, Milady | Centurion, Oracle, Witness, Prodigal Son, Doppel, Ouroboros, Anointer, Serpent, Bound One, Phoenix |
+| Basis | Rave movement, assigned from astrological birth data | Esoteric/tarot role, chosen by answering the quiz |
+| Where | A generative trait on each of the 10,000 Miberas ([`core-lore/archetypes.md`](../../core-lore/archetypes.md)) | This soulbound token, one per wallet |
 
-The Mibera universe defines four primary archetypes tied to zodiac signs and rave eras:
+The contract name "ArchetypeAlignment" and token name "miChainMirror" refer to the **10 quiz archetypes** — the quiz "mirrors" a wallet's identity into one of the ten esoteric roles. It does **not** assign a trait archetype. Full detail: [`core-lore/archetype-quiz/`](../../core-lore/archetype-quiz/README.md).
 
-| Archetype | Zodiac Signs | Season | Era |
-|-----------|--------------|--------|-----|
-| **Freetekno** | Cancer, Leo, Virgo | Summer | Early-Late 90s |
-| **Milady** | Capricorn, Aquarius, Pisces | Winter | Current |
-| **Chicago Detroit** | Aries, Taurus, Gemini | Spring | Early 80s |
-| **Acidhouse** | Libra, Scorpio, Sagittarius | Fall | Late 90s / 2000s |
+## Not related to the 78 drug-tarot cards
 
-In the main Mibera collection (10,000 NFTs), archetypes are assigned based on astrological birth data. The Archetype Quiz likely offers an alternative path — rather than birth chart data, users answer personality/preference questions that map to the same archetype framework.
-
-<!-- GAP: The sprint plan references "10 archetypes" but the codex documents only 4 primary archetypes. It is possible the quiz uses a finer-grained classification (e.g., sub-archetypes or archetype + ancestor combinations), or the "10" may refer to a different categorization system. The exact mapping between quiz outcomes and the documented archetypes has not been confirmed. -->
-
-## Relationship to the Drug-Tarot System
-
-The Mibera codex maps 78 tarot cards to 78 drugs across four suits (Wands/Fire, Cups/Water, Swords/Air, Pentacles/Earth). Each archetype has natural affinities with certain drug categories. The "Tarot Quiz" name suggests the quiz may incorporate tarot card symbolism in its question framing or result presentation.
-
-<!-- GAP: It is unknown whether the quiz result includes a specific tarot card assignment alongside the archetype, or whether "Tarot Quiz" is simply the colloquial name for the archetype alignment quiz. The contract and ABI contain no tarot-specific data structures. -->
+The codex's [drug-tarot system](../../core-lore/drug-tarot-system.md) — the **78 tarot cards mapped to 78 drugs** across four suits (Wands/Fire, Cups/Water, Swords/Air, Pentacles/Earth) — has **nothing to do with this quiz**. "Tarot Quiz" is merely the frontend's colloquial nickname for the Archetype Quiz. The quiz does not draw, assign, or reference any of the 78 tarot cards; its questions and results map only to the [10 quiz archetypes](../../core-lore/archetype-quiz/README.md). The contract and ABI contain no tarot-specific data structures. The two systems share the word "tarot" and nothing else.
 
 ## Key Errors
 

--- a/core-lore/archetype-quiz/README.md
+++ b/core-lore/archetype-quiz/README.md
@@ -1,0 +1,66 @@
+# Archetype Quiz
+
+*The soulbound personality quiz that maps a wallet to one of ten esoteric archetypes — distinct from the four rave-tribe trait archetypes of the main collection.*
+
+---
+
+## Two archetype systems (read this first)
+
+Mibera uses the word **archetype** for two unrelated things. Do not conflate them.
+
+| | Trait archetypes | Quiz archetypes (this section) |
+|---|---|---|
+| Count | **4** | **10** |
+| Members | Freetekno, Chicago/Detroit, Acidhouse, Milady | Centurion, Oracle, Witness, Prodigal Son, Doppel, Ouroboros, Anointer, Serpent, Bound One, Phoenix |
+| Basis | Rave-culture movements, assigned from astrological birth data | Esoteric/tarot roles, chosen by answering a personality quiz |
+| Home | [`core-lore/archetypes.md`](../archetypes.md) | this section |
+| On-chain | A generative trait on each of the 10,000 Miberas | A separate soulbound token, `MiberaArchetypeAlignment` (MIRA) |
+
+The two systems share no members and are computed by completely different mechanisms. The quiz is an **alternative identity ritual** layered on top of the collection, not a second way to compute a trait archetype.
+
+**Also not related:** the codex's [78 drug-tarot cards](../drug-tarot-system.md) (78 tarot cards ↔ 78 drugs). "Tarot Quiz" is just the frontend's nickname for this Archetype Quiz — it draws no tarot cards and references none of the 78. The two systems share the word "tarot" and nothing else.
+
+## What the quiz is
+
+The Archetype Quiz (frontend-branded "Tarot Quiz") is an **off-chain, 7-question** personality quiz. Each answer maps to one of the 10 quiz archetypes. Your answers are tallied and projected onto a 2-axis grid; the result is your **dominant archetype** plus a **secondary** and **tertiary**. On-chain holdings apply weighted "boosts" that pull your grid position. Completing the quiz lets you mint a **soulbound** (non-transferable, one-per-wallet) NFT — `miChainMirror` / **MIRA** — that records the result. The token art is your archetype sigil.
+
+- **The 7 questions, all 70 answers, and the full scoring engine** → [`quiz-questions.md`](quiz-questions.md)
+- **The 10 archetypes** (essence, description, grid position, art) → [`archetypes/`](archetypes/)
+- **Esoteric roles, on-chain actions, and boost weights** → [`esoteric-roles.md`](esoteric-roles.md)
+- **The MIRA contract mechanics** → [`../../_codex/data/tarot-quiz.md`](../../_codex/data/tarot-quiz.md)
+
+## The 10 archetypes
+
+| Archetype | Symbol | Grid disposition (Chaos↔Order, Hidden↔Visible) |
+|-----------|:------:|--------------------------------------------------|
+| [Centurion](archetypes/centurion.md) | 🛡 | Order, Visible |
+| [Oracle](archetypes/oracle.md) | 🌒 | Chaos, Hidden |
+| [Witness](archetypes/witness.md) | 🐈 | Slightly Order, Very Hidden |
+| [Prodigal Son](archetypes/prodigal-son.md) | 🧠 | Chaos, Visible |
+| [Doppel](archetypes/doppel.md) | 🪞 | Very Chaos, Slightly Visible |
+| [Ouroboros](archetypes/ouroboros.md) | 🚨 | Very Order, Slightly Visible |
+| [Anointer](archetypes/anointer.md) | 🧃 | Order, Hidden |
+| [Serpent](archetypes/serpent.md) | 🐍 | Chaos, Hidden |
+| [Bound One](archetypes/bound-one.md) | ⛓️ | Neutral, Very Hidden |
+| [Phoenix](archetypes/phoenix.md) | 🔥 | Order, Hidden |
+
+> Note: the frontend ships an eleventh sigil image, `Apostate.png`, that is not one of the ten scoreable archetypes. It appears to be an unused or special-case asset; no quiz answer maps to it.
+
+## The grid
+
+Every archetype sits on a 2D plane. Two axes:
+
+- **X — Chaos (−100) ↔ Order (+100)**
+- **Y — Hidden (−100) ↔ Visible (+100)**
+
+Your answers place you at an average position; on-chain boosts nudge it; the archetype whose bounding box contains your point (or is nearest) becomes dominant. See [`quiz-questions.md`](quiz-questions.md) for the exact vectors and ranges.
+
+## Provenance
+
+This section reconstructs the quiz from its original frontend implementation in the private `0xHoneyJar/mibera-honeyroad` repository, recovered at commit `0db63db0` — the last state before the quiz UI was retired in the 2026-05-16 wind-down (commit `3246f324`). Source files:
+
+- `components/quiz-page.tsx` — questions, archetype copy, symbols
+- `lib/hooks/use-quiz.ts` — scoring engine (vectors, ranges, boosts, roles, actions)
+- `constants/quiz.ts` — art paths and config
+
+The MIRA contract remains live on Berachain; historical token metadata is still served from the `quiz_metadata` Postgres table via `app/api/quiz/[tokenId]/route.ts`. Everything here is transcribed from those sources, not inferred.

--- a/core-lore/archetype-quiz/archetypes/anointer.md
+++ b/core-lore/archetype-quiz/archetypes/anointer.md
@@ -1,0 +1,33 @@
+---
+name: Anointer
+symbol: "🧃"
+system: archetype-quiz
+base_vector: [80, -50]
+grid_x_range: [12, 68]
+grid_y_range: [-53, 3]
+disposition: Order, Hidden
+art: public/archetypes/Anointer.png
+art_cdn_base: https://assets.0xhoneyjar.xyz/Mibera/quiz_archetypes/
+forced_eligible: false
+---
+
+# Anointer 🧃
+
+> *"With unseen hands, they bless the improbable; seeding myths in the barren soil of chaos."*
+
+## Essence
+
+The Anointer finds meaning in experiences and has the ability to elevate and bless others through their words and actions. You have a talent for recognizing the potential in people and situations and helping them reach that potential.
+
+**Signature contribution:** Amplify and validate others.
+
+## Grid position
+
+- **Base vector:** (80, −50) — Order, Hidden
+- **Range:** X [12, 68], Y [−53, 3]
+
+On the [quiz grid](../quiz-questions.md), the Anointer works the Order/Hidden field: quietly conferring meaning and status onto others.
+
+## System
+
+One of the ten [Archetype Quiz](../README.md) archetypes — an esoteric role assigned by the soulbound [MIRA quiz](../../../_codex/data/tarot-quiz.md), distinct from the four rave-tribe [trait archetypes](../../archetypes.md).

--- a/core-lore/archetype-quiz/archetypes/bound-one.md
+++ b/core-lore/archetype-quiz/archetypes/bound-one.md
@@ -1,0 +1,33 @@
+---
+name: Bound One
+symbol: "⛓️"
+system: archetype-quiz
+base_vector: [0, -100]
+grid_x_range: [-28, 28]
+grid_y_range: [-75.5, -19.5]
+disposition: Neutral, Very Hidden
+art: public/archetypes/Bound One.png
+art_cdn_base: https://assets.0xhoneyjar.xyz/Mibera/quiz_archetypes/
+forced_eligible: false
+---
+
+# Bound One ⛓️
+
+> *"Cursed by foresight, shackled by care; yet within the stillness, new worlds dream."*
+
+## Essence
+
+The Bound One remains steadfast through all changes, enduring challenges with quiet strength. You have a remarkable ability to stay committed to your path even when circumstances are difficult.
+
+**Signature contribution:** Endure the vibes.
+
+## Grid position
+
+- **Base vector:** (0, −100) — Neutral, Very Hidden
+- **Range:** X [−28, 28], Y [−75.5, −19.5]
+
+On the [quiz grid](../quiz-questions.md), the Bound One sits at the absolute bottom-center (most Hidden): enduring, patient, load-bearing in silence.
+
+## System
+
+One of the ten [Archetype Quiz](../README.md) archetypes — an esoteric role assigned by the soulbound [MIRA quiz](../../../_codex/data/tarot-quiz.md), distinct from the four rave-tribe [trait archetypes](../../archetypes.md).

--- a/core-lore/archetype-quiz/archetypes/centurion.md
+++ b/core-lore/archetype-quiz/archetypes/centurion.md
@@ -1,0 +1,33 @@
+---
+name: Centurion
+symbol: "🛡"
+system: archetype-quiz
+base_vector: [60, 60]
+grid_x_range: [2, 58]
+grid_y_range: [2, 58]
+disposition: Order, Visible
+art: public/archetypes/Centurion.png
+art_cdn_base: https://assets.0xhoneyjar.xyz/Mibera/quiz_archetypes/
+forced_eligible: false
+---
+
+# Centurion 🛡
+
+> *"Between crumbling empires and burning skies, the builder binds the fragments into futures."*
+
+## Essence
+
+The Centurion is a steadfast guardian of the community, standing firm against chaos and protecting the values that matter most. You are loyal, reliable, and willing to defend what you believe in, even when the path is difficult.
+
+**Signature contribution:** Build and show up.
+
+## Grid position
+
+- **Base vector:** (60, 60) — Order, Visible
+- **Range:** X [2, 58], Y [2, 58]
+
+On the [quiz grid](../quiz-questions.md), the Centurion anchors the Order/Visible quadrant: public, dependable, structural.
+
+## System
+
+One of the ten [Archetype Quiz](../README.md) archetypes — an esoteric role assigned by the soulbound [MIRA quiz](../../../_codex/data/tarot-quiz.md), distinct from the four rave-tribe [trait archetypes](../../archetypes.md).

--- a/core-lore/archetype-quiz/archetypes/doppel.md
+++ b/core-lore/archetype-quiz/archetypes/doppel.md
@@ -1,0 +1,33 @@
+---
+name: Doppel
+symbol: "🪞"
+system: archetype-quiz
+base_vector: [-90, 20]
+grid_x_range: [-73, -17]
+grid_y_range: [-18, 38]
+disposition: Very Chaos, Slightly Visible
+art: public/archetypes/Doppel.png
+art_cdn_base: https://assets.0xhoneyjar.xyz/Mibera/quiz_archetypes/
+forced_eligible: false
+---
+
+# Doppel 🪞
+
+> *"The mask shifts not to deceive, but to reveal what the mirror forgets."*
+
+## Essence
+
+The Doppel is a shape-shifter who can adapt to any situation and reflect different aspects of themselves as needed. You have a chameleon-like ability to fit in wherever you go while maintaining your core identity.
+
+**Signature contribution:** Stir things up.
+
+## Grid position
+
+- **Base vector:** (−90, 20) — Very Chaos, Slightly Visible
+- **Range:** X [−73, −17], Y [−18, 38]
+
+On the [quiz grid](../quiz-questions.md), the Doppel sits at the far Chaos edge: mutable, reflective, hardest to pin down.
+
+## System
+
+One of the ten [Archetype Quiz](../README.md) archetypes — an esoteric role assigned by the soulbound [MIRA quiz](../../../_codex/data/tarot-quiz.md), distinct from the four rave-tribe [trait archetypes](../../archetypes.md).

--- a/core-lore/archetype-quiz/archetypes/oracle.md
+++ b/core-lore/archetype-quiz/archetypes/oracle.md
@@ -1,0 +1,33 @@
+---
+name: Oracle
+symbol: "🌒"
+system: archetype-quiz
+base_vector: [-40, -70]
+grid_x_range: [-48, 8]
+grid_y_range: [-63, -7]
+disposition: Chaos, Hidden
+art: public/archetypes/Oracle.png
+art_cdn_base: https://assets.0xhoneyjar.xyz/Mibera/quiz_archetypes/
+forced_eligible: false
+---
+
+# Oracle 🌒
+
+> *"From unseen currents they weave the map; not to be followed, but to be understood."*
+
+## Essence
+
+The Oracle possesses a unique ability to see beyond the present moment and interpret signs that others might miss. You have an intuitive understanding of patterns and can often predict outcomes before they unfold.
+
+**Signature contribution:** Receive and translate visions.
+
+## Grid position
+
+- **Base vector:** (−40, −70) — Chaos, Hidden
+- **Range:** X [−48, 8], Y [−63, −7]
+
+On the [quiz grid](../quiz-questions.md), the Oracle sits deep in the Chaos/Hidden field: intuitive, submerged, reading currents others can't see.
+
+## System
+
+One of the ten [Archetype Quiz](../README.md) archetypes — an esoteric role assigned by the soulbound [MIRA quiz](../../../_codex/data/tarot-quiz.md), distinct from the four rave-tribe [trait archetypes](../../archetypes.md).

--- a/core-lore/archetype-quiz/archetypes/ouroboros.md
+++ b/core-lore/archetype-quiz/archetypes/ouroboros.md
@@ -1,0 +1,35 @@
+---
+name: Ouroboros
+symbol: "🚨"
+system: archetype-quiz
+base_vector: [90, 20]
+grid_x_range: [17, 73]
+grid_y_range: [-18, 38]
+disposition: Very Order, Slightly Visible
+art: public/archetypes/Ouroboros.png
+art_cdn_base: https://assets.0xhoneyjar.xyz/Mibera/quiz_archetypes/
+forced_eligible: true
+---
+
+# Ouroboros 🚨
+
+> *"In the spiral of endings and beginnings, the one who remembers shapes the next dawn."*
+
+## Essence
+
+The Ouroboros recognizes patterns and cycles in life, understanding that history often repeats itself. You have a deep appreciation for the cyclical nature of existence and can see how past events influence the present.
+
+**Signature contribution:** Keep the wheel turning.
+
+## Grid position
+
+- **Base vector:** (90, 20) — Very Order, Slightly Visible
+- **Range:** X [17, 73], Y [−18, 38]
+
+On the [quiz grid](../quiz-questions.md), the Ouroboros holds the far Order edge: the one who has seen the loop before and names it.
+
+> **Forced-eligible:** one of the three archetypes (with Phoenix and Prodigal Son) that a `forced_archetype` record can assign directly, overriding the answer tally.
+
+## System
+
+One of the ten [Archetype Quiz](../README.md) archetypes — an esoteric role assigned by the soulbound [MIRA quiz](../../../_codex/data/tarot-quiz.md), distinct from the four rave-tribe [trait archetypes](../../archetypes.md).

--- a/core-lore/archetype-quiz/archetypes/phoenix.md
+++ b/core-lore/archetype-quiz/archetypes/phoenix.md
@@ -1,0 +1,35 @@
+---
+name: Phoenix
+symbol: "🔥"
+system: archetype-quiz
+base_vector: [40, -20]
+grid_x_range: [-8, 48]
+grid_y_range: [-38, 18]
+disposition: Order, Hidden
+art: public/archetypes/Phoenix.png
+art_cdn_base: https://assets.0xhoneyjar.xyz/Mibera/quiz_archetypes/
+forced_eligible: true
+---
+
+# Phoenix 🔥
+
+> *"Ash is not the end, but the memory of flame choosing to burn again."*
+
+## Essence
+
+The Phoenix rises from the ashes of destruction, transforming challenges into opportunities for renewal. You have an incredible ability to rebuild and reinvent yourself after setbacks, emerging stronger than before.
+
+**Signature contribution:** Transform and inspire.
+
+## Grid position
+
+- **Base vector:** (40, −20) — Order, Hidden
+- **Range:** X [−8, 48], Y [−38, 18]
+
+On the [quiz grid](../quiz-questions.md), the Phoenix sits near center-Order: the one who burns down and rebuilds, again and again.
+
+> **Forced-eligible:** one of the three archetypes (with Prodigal Son and Ouroboros) that a `forced_archetype` record can assign directly, overriding the answer tally.
+
+## System
+
+One of the ten [Archetype Quiz](../README.md) archetypes — an esoteric role assigned by the soulbound [MIRA quiz](../../../_codex/data/tarot-quiz.md), distinct from the four rave-tribe [trait archetypes](../../archetypes.md).

--- a/core-lore/archetype-quiz/archetypes/prodigal-son.md
+++ b/core-lore/archetype-quiz/archetypes/prodigal-son.md
@@ -1,0 +1,35 @@
+---
+name: Prodigal Son
+symbol: "🧠"
+system: archetype-quiz
+base_vector: [-60, 60]
+grid_x_range: [-58, -2]
+grid_y_range: [2, 58]
+disposition: Chaos, Visible
+art: public/archetypes/Prodigal Son.png
+art_cdn_base: https://assets.0xhoneyjar.xyz/Mibera/quiz_archetypes/
+forced_eligible: true
+---
+
+# Prodigal Son 🧠
+
+> *"The exile returns, not for forgiveness, but to bear witness to the illusions they once believed."*
+
+## Essence
+
+The Prodigal Son sees through illusions and isn't afraid to speak harsh truths, even when they're unpopular. You have a critical eye and aren't swayed by groupthink or emotional appeals.
+
+**Signature contribution:** Provide sharp critique.
+
+## Grid position
+
+- **Base vector:** (−60, 60) — Chaos, Visible
+- **Range:** X [−58, −2], Y [2, 58]
+
+On the [quiz grid](../quiz-questions.md), the Prodigal Son holds the Chaos/Visible quadrant: loud dissent, the critic who refuses the consensus.
+
+> **Forced-eligible:** one of the three archetypes (with Phoenix and Ouroboros) that a `forced_archetype` record can assign directly, overriding the answer tally.
+
+## System
+
+One of the ten [Archetype Quiz](../README.md) archetypes — an esoteric role assigned by the soulbound [MIRA quiz](../../../_codex/data/tarot-quiz.md), distinct from the four rave-tribe [trait archetypes](../../archetypes.md).

--- a/core-lore/archetype-quiz/archetypes/serpent.md
+++ b/core-lore/archetype-quiz/archetypes/serpent.md
@@ -1,0 +1,33 @@
+---
+name: Serpent
+symbol: "🐍"
+system: archetype-quiz
+base_vector: [-60, -60]
+grid_x_range: [-58, -2]
+grid_y_range: [-58, -2]
+disposition: Chaos, Hidden
+art: public/archetypes/Serpent.png
+art_cdn_base: https://assets.0xhoneyjar.xyz/Mibera/quiz_archetypes/
+forced_eligible: false
+---
+
+# Serpent 🐍
+
+> *"The bearer of venom and vision alike; who tastes knowledge and poisons certainty."*
+
+## Essence
+
+The Serpent brings hidden knowledge to light, even when it's uncomfortable or painful. You have a talent for revealing truth and aren't afraid to challenge established beliefs or authority.
+
+**Signature contribution:** Reveal hidden truths.
+
+## Grid position
+
+- **Base vector:** (−60, −60) — Chaos, Hidden
+- **Range:** X [−58, −2], Y [−58, −2]
+
+On the [quiz grid](../quiz-questions.md), the Serpent holds the Chaos/Hidden quadrant: the whispered truth that unsettles the consensus.
+
+## System
+
+One of the ten [Archetype Quiz](../README.md) archetypes — an esoteric role assigned by the soulbound [MIRA quiz](../../../_codex/data/tarot-quiz.md), distinct from the four rave-tribe [trait archetypes](../../archetypes.md).

--- a/core-lore/archetype-quiz/archetypes/witness.md
+++ b/core-lore/archetype-quiz/archetypes/witness.md
@@ -1,0 +1,33 @@
+---
+name: Witness
+symbol: "🐈"
+system: archetype-quiz
+base_vector: [10, -90]
+grid_x_range: [-23, 33]
+grid_y_range: [-73, -17]
+disposition: Slightly Order, Very Hidden
+art: public/archetypes/Witness.png
+art_cdn_base: https://assets.0xhoneyjar.xyz/Mibera/quiz_archetypes/
+forced_eligible: false
+---
+
+# Witness 🐈
+
+> *"The silent archive watches not with judgment, but with an ache for what might yet be woven."*
+
+## Essence
+
+The Witness observes and records without judgment, maintaining a clear memory of events as they unfold. You have a talent for seeing the truth in situations and preserving important knowledge for future reference.
+
+**Signature contribution:** Observe and remember.
+
+## Grid position
+
+- **Base vector:** (10, −90) — Slightly Order, Very Hidden
+- **Range:** X [−23, 33], Y [−73, −17]
+
+On the [quiz grid](../quiz-questions.md), the Witness sits at the very bottom (Very Hidden): present but unseen, the memory of the room.
+
+## System
+
+One of the ten [Archetype Quiz](../README.md) archetypes — an esoteric role assigned by the soulbound [MIRA quiz](../../../_codex/data/tarot-quiz.md), distinct from the four rave-tribe [trait archetypes](../../archetypes.md).

--- a/core-lore/archetype-quiz/esoteric-roles.md
+++ b/core-lore/archetype-quiz/esoteric-roles.md
@@ -1,0 +1,96 @@
+# Esoteric Roles, On-Chain Actions & Boosts
+
+The three sets of modifiers that shift a wallet's grid position before the dominant archetype is chosen. All values transcribed verbatim from `mibera-honeyroad` (`lib/hooks/use-quiz.ts`, `components/quiz-page.tsx`).
+
+Each modifier is a vector `{x, y}` added to the position, where **X = Chaos(−) ↔ Order(+)** and **Y = Hidden(−) ↔ Visible(+)**. See [`quiz-questions.md`](quiz-questions.md) for how the position is computed.
+
+---
+
+## Esoteric Roles
+
+A tier earned by how many Mibera-ecosystem NFTs the wallet holds. Higher tiers nudge the position toward Order/Visible. Art: `public/Esoteric/{ROLE}.png` in the frontend.
+
+| Role | NFT count | Vector (x, y) |
+|------|----------:|:-------------:|
+| Seeker | 1 | (−10, −10) |
+| Neophyte | 2 | (−5, 0) |
+| Acolyte | 5 | (0, 5) |
+| Adept | 10 | (5, 10) |
+| Alchemist | 25 | (10, 15) |
+| Sigil Mage | 50 | (15, 20) |
+| Keeper of Keys | 100 | (20, 25) |
+| Chain Archivist | 250 | (25, 30) |
+| The Contract | 500 | (30, 35) |
+
+## On-Chain Actions
+
+A single declared "how you behaved" flag. Art: `public/badges/{action}.png`.
+
+| Action | Vector (x, y) | Reading |
+|--------|:-------------:|---------|
+| crazy | (−20, 10) | Chaos, Visible |
+| cradled | (10, −10) | Order, Hidden |
+| capitulate | (−15, −15) | Chaos, Hidden |
+| Collectooor | (15, 5) | Order, Visible |
+| Comeback | (0, 20) | Neutral, Very Visible |
+| Cashed out | (−10, 0) | Chaos, Neutral |
+
+## Boosts
+
+On-chain holdings and contributions that pull the position toward a specific archetype's quadrant. Each is a boolean flag on the wallet's quiz record; when true, its vector is added. Badge art: `public/badges/{name}.png`.
+
+### NFT holdings
+
+| Boost | Vector (x, y) | Pulls toward |
+|-------|:-------------:|--------------|
+| apDAO | (−20, −20) | Serpent (Chaos, Hidden) |
+| Honeycomb | (−30, −40) | Oracle (Chaos, Very Hidden) |
+| Bulla | (30, 30) | Centurion (Order, Visible) |
+| Tedism | (−10, 20) | Phoenix / Serpent (Chaos, Visible) |
+| Parcel | (−40, 10) | Doppel (Very Chaos, Slightly Visible) |
+| Miladies | (20, −10) | Phoenix (Order, Hidden) |
+| MiReveal | (25, 25) | Centurion (Order, Visible) |
+
+### Drug-related
+
+| Boost | Vector (x, y) | Pulls toward |
+|-------|:-------------:|--------------|
+| Cheap drugs | (−25, −35) | Oracle (Chaos, Hidden) |
+| Expensive drugs | (15, 15) | Phoenix / Centurion (Order, Visible) |
+
+### Shadow-trait count
+
+| Boost | Vector (x, y) | Pulls toward |
+|-------|:-------------:|--------------|
+| 1 shadow | (−15, −15) | Serpent (Chaos, Hidden) |
+| 2–10 shadows | (10, −10) | Phoenix (Order, Hidden) |
+| 10+ shadows | (40, −30) | Anointer (Order, Hidden) |
+
+### Mibera Set tier
+
+| Boost | Vector (x, y) | Pulls toward |
+|-------|:-------------:|--------------|
+| Set holder | (5, −45) | Witness (Slightly Order, Very Hidden) |
+| Strong set holder | (−35, 10) | Doppel (Very Chaos, Slightly Visible) |
+| Super set holder | (35, 35) | Centurion (Order, Visible) |
+
+### Contribution
+
+| Boost | Vector (x, y) | Pulls toward |
+|-------|:-------------:|--------------|
+| Articles | (−20, −30) | Oracle (Chaos, Hidden) |
+| Delegator | (0, −30) | Witness (Neutral, Hidden) |
+| Scribe | (0, −50) | Bound One (Neutral, Very Hidden) |
+
+---
+
+## Order of operations
+
+1. Average the base vectors of the 7 answers → raw position.
+2. Add the esoteric-role adjustment.
+3. Add the on-chain action adjustment.
+4. Add every active boost vector.
+5. Clamp to ±100.
+6. Resolve the dominant archetype by bounding box, else nearest base vector.
+
+The `forced_archetype` override (Phoenix / Prodigal Son / Ouroboros only) short-circuits this and wins outright.

--- a/core-lore/archetype-quiz/quiz-questions.md
+++ b/core-lore/archetype-quiz/quiz-questions.md
@@ -1,0 +1,172 @@
+# Quiz Questions & Scoring
+
+The full 7-question quiz, all 70 answer options, and the scoring engine — transcribed verbatim from `mibera-honeyroad` (`components/quiz-page.tsx`, `lib/hooks/use-quiz.ts`).
+
+Questions are presented in a **randomized order** per session (shuffled on mount). Every question offers exactly **one answer per archetype**, so the ten options below always appear in the same archetype order.
+
+---
+
+## The 7 questions
+
+### Q1 — *"You receive a parcel from Mibera. It says: 'Mibera is now Miladies.' Timeline splits. What do you do?"*
+
+| Answer | Archetype |
+|--------|-----------|
+| Change pfp first, ask never | Centurion |
+| Cast divination, summon the chat | Oracle |
+| Wait to see how it plays out | Witness |
+| Post "this is low effort trash" | Prodigal Son |
+| Remix the NFT into memes | Doppel |
+| Say "we've been here before", this isn't the real reveal | Ouroboros |
+| Slide into DMs and mint new meaning | Anointer |
+| Post "this was written" then vanish | Serpent |
+| Save every tweet, say nothing | Bound One |
+| Burn it or Burn something | Phoenix |
+
+### Q2 — *"The Discord is nuked. Founders radio silent or Raging. Timeline in flames. What do you do?"*
+
+| Answer | Archetype |
+|--------|-----------|
+| Meme through it | Centurion |
+| Drop a prophecy and vanish | Oracle |
+| Refresh and observe | Witness |
+| "Y'all got rugged again huh" | Prodigal Son |
+| Post fake leaks to stir it | Doppel |
+| "Another loop begins" | Ouroboros |
+| Bless the ashes | Anointer |
+| "Judgment has come" | Serpent |
+| Scroll silently, feel cursed | Bound One |
+| Burn it all, start again | Phoenix |
+
+### Q3 — *"A community ritual spreads. Miladies being commented under confused Milady pfps. Comment waves. What's your move?"*
+
+| Answer | Archetype |
+|--------|-----------|
+| Run ops, no permission needed | Centurion |
+| Share lore, connect the symbols | Oracle |
+| Watch the ritual, say nothing | Witness |
+| Say "this is cringe" | Prodigal Son |
+| Become the ritual | Doppel |
+| Echo its prior versions | Ouroboros |
+| Declare meaning, crown it | Anointer |
+| Post sigils of awakening | Serpent |
+| Archive everything | Bound One |
+| Join, but note "all things must pass" | Phoenix |
+
+### Q4 — *"Some meme Miladies. Others mourn. What's your response?"*
+
+| Answer | Archetype |
+|--------|-----------|
+| Comment "we ride again" | Centurion |
+| Post prophecy | Oracle |
+| Screenshot and save | Witness |
+| "Grift energy lol" | Prodigal Son |
+| Post both sides of the meme war | Doppel |
+| Share image from 6 cycles ago | Ouroboros |
+| Bless it and elevate it | Anointer |
+| "They awaken the old gods" | Serpent |
+| Say nothing, absorb everything | Bound One |
+| "Let this meme die with honor" | Phoenix |
+
+### Q5 — *"The floor crashes. What now?"*
+
+| Answer | Archetype |
+|--------|-----------|
+| "There is no chart" | Centurion |
+| Decode the fall | Oracle |
+| Lurk and log it | Witness |
+| "Told you it was a rug" | Prodigal Son |
+| Start chaos posts | Doppel |
+| Post a spiral or ouroboric sigil | Ouroboros |
+| Find meaning in the ashes | Anointer |
+| "Karma loop complete" | Serpent |
+| Feel the loss, hold the line | Bound One |
+| Exit, re-enter stronger | Phoenix |
+
+### Q6 — *"Your ideal contribution to the community is…"*
+
+| Answer | Archetype |
+|--------|-----------|
+| Build and show up | Centurion |
+| Receive and translate visions | Oracle |
+| Observe and remember | Witness |
+| Provide sharp critique | Prodigal Son |
+| Stir things up | Doppel |
+| Keep the wheel turning | Ouroboros |
+| Amplify and validate others | Anointer |
+| Reveal hidden truths | Serpent |
+| Endure the vibes | Bound One |
+| Transform and inspire | Phoenix |
+
+### Q7 — *"Pick a symbol:"*
+
+| Answer | Archetype |
+|--------|-----------|
+| 🛡 | Centurion |
+| 🌒 | Oracle |
+| 🐈 | Witness |
+| 🧠 | Prodigal Son |
+| 🪞 | Doppel |
+| 🚨 | Ouroboros |
+| 🧃 | Anointer |
+| 🐍 | Serpent |
+| ⛓️ | Bound One |
+| 🔥 | Phoenix |
+
+---
+
+## Scoring engine
+
+The result is computed in two complementary layers.
+
+### Layer 1 — Answer tally (dominant archetype)
+
+1. Each of the 7 answers awards **+1 point** to its archetype.
+2. The archetype with the most points is **dominant**.
+3. **Ties are broken at random** among the highest-scoring archetypes.
+4. A `forced_archetype` flag in the wallet's quiz record can override the tally — but only for **Phoenix, Prodigal Son, or Ouroboros** (used for special/seeded assignments).
+
+### Layer 2 — The grid (position, secondary, tertiary)
+
+Two axes define a −100…+100 plane:
+
+- **X — Chaos (−100) ↔ Order (+100)**
+- **Y — Hidden (−100) ↔ Visible (+100)**
+
+**Archetype base vectors** (their "home" coordinates):
+
+| Archetype | X | Y | Reading |
+|-----------|---:|---:|---------|
+| Centurion | 60 | 60 | Order, Visible |
+| Oracle | −40 | −70 | Chaos, Hidden |
+| Witness | 10 | −90 | Slightly Order, Very Hidden |
+| Prodigal Son | −60 | 60 | Chaos, Visible |
+| Doppel | −90 | 20 | Very Chaos, Slightly Visible |
+| Ouroboros | 90 | 20 | Very Order, Slightly Visible |
+| Anointer | 80 | −50 | Order, Hidden |
+| Serpent | −60 | −60 | Chaos, Hidden |
+| Bound One | 0 | −100 | Neutral, Very Hidden |
+| Phoenix | 40 | −20 | Order, Hidden |
+
+**Position** = the average of the base vectors of your 7 chosen answers, clamped to ±100. On-chain **boosts** (see [`esoteric-roles.md`](esoteric-roles.md)) are then added to shift the point.
+
+**Bounding ranges** — if your position falls inside an archetype's box, that archetype is selected; otherwise the **nearest base vector by Euclidean distance** wins:
+
+| Archetype | X range | Y range |
+|-----------|---------|---------|
+| Centurion | [2, 58] | [2, 58] |
+| Ouroboros | [17, 73] | [−18, 38] |
+| Prodigal Son | [−58, −2] | [2, 58] |
+| Doppel | [−73, −17] | [−18, 38] |
+| Oracle | [−48, 8] | [−63, −7] |
+| Serpent | [−58, −2] | [−58, −2] |
+| Phoenix | [−8, 48] | [−38, 18] |
+| Witness | [−23, 33] | [−73, −17] |
+| Anointer | [12, 68] | [−53, 3] |
+| Bound One | [−28, 28] | [−75.5, −19.5] |
+
+**Secondary + tertiary archetypes** = the 2nd- and 3rd-nearest base vectors to your final position (excluding the dominant one). These are what the token's metadata records alongside the primary.
+
+### What lands on-chain
+
+The `mint()` call itself carries **no archetype data** — the token ID is sequential. The archetype, grid vector, and secondary are written to the off-chain `quiz_metadata` Postgres record and served through the contract's `baseURI`. See [`../../_codex/data/tarot-quiz.md`](../../_codex/data/tarot-quiz.md) for contract mechanics.

--- a/core-lore/archetypes.md
+++ b/core-lore/archetypes.md
@@ -8,6 +8,8 @@
 
 Each Archetype represents a distinct rave movement, era, and aesthetic. Miberas are assigned to an Archetype based on their astrological birth data.
 
+> **Not to be confused with the quiz archetypes.** These **4** are the load-bearing NFT *trait* archetypes. A separate system — the soulbound [Archetype Quiz (MIRA)](archetype-quiz/README.md) — assigns wallets one of **10** unrelated esoteric archetypes (Centurion, Oracle, Witness, …) by answering a personality quiz. The two share the word "archetype" and nothing else: no common members, different mechanism.
+
 ### Archetype-Astrology Mapping
 
 | Archetype | Zodiac Signs | Season | Era |

--- a/glossary.md
+++ b/glossary.md
@@ -16,6 +16,11 @@ One of four primary Rave Tribes that define aesthetic and philosophical foundati
 - **[Chicago Detroit](core-lore/archetypes.md#chicago-detroit)** — Early 80s house/techno origins (Spring: Aries, Taurus, Gemini)
 - **[Acidhouse](core-lore/archetypes.md#acidhouse)** — Late 90s/2000s acid house revival (Fall: Libra, Scorpio, Sagittarius)
 
+Distinct from **[Quiz Archetype](#quiz-archetype)** — the 10 esoteric archetypes from the soulbound MIRA quiz. Unrelated systems.
+
+### Quiz Archetype
+One of **10** esoteric archetypes (Centurion, Oracle, Witness, Prodigal Son, Doppel, Ouroboros, Anointer, Serpent, Bound One, Phoenix) assigned by the off-chain [Archetype Quiz](core-lore/archetype-quiz/README.md) and recorded on-chain in the soulbound MIRA (`miChainMirror`) token. Separate from the 4 [Archetype](#archetype) trait tribes and from the 78 drug-tarot cards — the three systems are unrelated.
+
 ---
 
 ## C

--- a/manifest.json
+++ b/manifest.json
@@ -159,6 +159,15 @@
         "shirts": 19,
         "tattoos": 1
       }
+    },
+    "quiz_archetype": {
+      "directory": "core-lore/archetype-quiz/archetypes/",
+      "index": "core-lore/archetype-quiz/README.md",
+      "count": 10,
+      "format": "yaml_frontmatter",
+      "completeness": "COMPLETE",
+      "completeness_note": "10 esoteric archetypes from the soulbound MIRA quiz; distinct from the 4 trait archetypes and the 78 drug-tarot cards",
+      "last_verified": "2026-07-08"
     }
   },
   "browse": {
@@ -185,7 +194,8 @@
     "schema": "_codex/schema/README.md",
     "llms": "llms.txt",
     "llms_full": "llms-full.txt",
-    "ontology": "_codex/schema/ontology.yaml"
+    "ontology": "_codex/schema/ontology.yaml",
+    "archetype_quiz": "core-lore/archetype-quiz/README.md"
   },
   "data_exports": {
     "miberas_jsonl": "_codex/data/miberas.jsonl",


### PR DESCRIPTION
## Summary

The **Archetype Quiz** was previously a stub in `_codex/data/tarot-quiz.md` with four `GAP` markers — the contract mechanics were documented, but the actual quiz (questions, answers, scoring, art) was missing because it lived off-chain in the private `mibera-honeyroad` frontend.

This PR recovers the full quiz from that frontend (at commit `0db63db0`, the last state before the quiz UI was retired in the 2026-05-16 wind-down) and documents it as a first-class codex section. Everything is transcribed verbatim from source — not inferred.

## What's new — `core-lore/archetype-quiz/`

- **`README.md`** — overview + disambiguation (vs the 4 trait archetypes **and** the 78 drug-tarot cards)
- **`quiz-questions.md`** — all **7 questions**, **70 answer options**, and the full scoring engine (answer tally + 2D grid: Chaos↔Order × Hidden↔Visible, base vectors, bounding ranges)
- **`esoteric-roles.md`** — 9 role tiers, 6 on-chain actions, 18 boosts (with vector adjustments + art paths)
- **`archetypes/*.md`** — 10 quiz-archetype entity files (Centurion, Oracle, Witness, Prodigal Son, Doppel, Ouroboros, Anointer, Serpent, Bound One, Phoenix)

## Corrections to existing docs

- **`_codex/data/tarot-quiz.md`** — fixes the **"four archetypes" error** (it's 10), resolves all 4 stale `GAP` markers, and adds an explicit note that the **78 drug-tarot cards are unrelated** to the quiz ("Tarot Quiz" is only the frontend's nickname).
- **`core-lore/archetypes.md` + `glossary.md`** — **bidirectional** disambiguation, so readers landing on the 4-trait-archetype pages are pointed to the separate 10-archetype quiz system (previously the disambiguation only existed on the quiz side).
- **`README.md` + `SUMMARY.md`** — nav links to the new section.
- **`manifest.json`** — registers `quiz_archetype` entity type (count 10) + `key_files` pointer.

## The three "archetype/tarot"-named systems, now mutually disambiguated

| System | Count | Home |
|---|---|---|
| Trait archetypes | 4 | `core-lore/archetypes.md` |
| Quiz archetypes | 10 | `core-lore/archetype-quiz/` |
| Drug-tarot cards | 78 | `core-lore/drug-tarot-system.md` |

## Validation

- Link auditor: **0 broken** across 294,987 links
- `manifest.json`: valid JSON, surgical diff (no reformatting churn)
- Provenance note in the section README cites the exact source files + commit

## Provenance

Source files (private `0xHoneyJar/mibera-honeyroad` @ `0db63db0`): `components/quiz-page.tsx`, `lib/hooks/use-quiz.ts`, `constants/quiz.ts`. The MIRA contract (`0x4B08a069381EfbB9f08C73D6B2e975C9BE3c4684`) remains live; historical token metadata is still served from the `quiz_metadata` Postgres table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)