### PR TITLE
fix(codex): correct Fractures deployment lineage

### DIFF
--- a/_codex/data/abis/README.md
+++ b/_codex/data/abis/README.md
@@ -14,9 +14,9 @@ ABI files for all Mibera ecosystem smart contracts, fetched from block explorers
 | BeraMarketMinter | `0x66660f4Bb0B7b11b9f12F613F4CF043516EB3b20` | `bera-market-minter.json` | Unverified |
 | MiberaTrade | `0x90485B61C9dA51A3c79fca1277899d9CD5D350c2` | `mibera-trade.json` | Unverified |
 | Accounts | `0xC0a78722889c7De7E6eF4B7dB1FeD5b4B97d6dA1` | `accounts.json` | Unverified |
-| FracturedMibera | `0x6956dae88C00372B1A0b2dfBfE5Eed19F85b0D4B` | `fractured-mibera.json` | Verified (39 entries) |
+| FracturedMibera (current phase 1) | `0x86db98cf1b81e833447b12a077ac28c36b75c8e1` | `fractured-mibera.json` | Verified (39 entries) |
 
-> All 10 FracturedMibera contracts share the same ABI. Only #1 was fetched.
+> All 10 current FracturedMibera contracts share the same ABI. The stored ABI was originally fetched from superseded phase 1 contract `0x6956dae88c00372b1a0b2dfbfe5eed19f85b0d4b`; its runtime bytecode is identical to the active replacement. See [_codex/data/fractured-mibera.md](../fractured-mibera.md) for lineage.
 
 ## Optimism (Chain 10)
 

--- a/_codex/data/contracts.json
+++ b/_codex/data/contracts.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.0",
-  "generated": "2026-02-18",
+  "version": "1.1.0",
+  "generated": "2026-07-18",
   "note": "There is NO on-chain distinction between generative Miberas and hand-drawn Grails. The codex is the only layer that knows which token IDs are 1/1s.",
   "contracts": [
     {
@@ -86,22 +86,163 @@
     },
     {
       "name": "FracturedMibera",
-      "address": "0x6956dae88C00372B1A0b2dfBfE5Eed19F85b0D4B",
+      "address": "0x86db98cf1b81e833447b12a077ac28c36b75c8e1",
       "chain": "berachain",
       "chain_id": 80094,
       "standard": "ERC-721 (soulbound)",
-      "notes": "10 soulbound companion collections. Token IDs mirror main Mibera. First of 10 contracts listed.",
+      "status": "active",
+      "registry_status": "verified_current",
+      "notes": "10 active soulbound companion collections. Token IDs mirror main Mibera. The address field is the current phase 1 contract; use phases or all_addresses for the complete current set.",
+      "provenance": {
+        "source_repository": "0xHoneyJar/mibera-contracts",
+        "source_issue": "https://github.com/0xHoneyJar/mibera-contracts/issues/2",
+        "codex_issue": "https://github.com/0xHoneyJar/construct-mibera-codex/issues/94",
+        "verified_at": "2026-07-18",
+        "verification_basis": [
+          "same deployer and ordered replacement nonces",
+          "identical runtime bytecode between superseded and current pairs",
+          "current replacements contain mint/Transfer activity while superseded contracts contain zero Transfer logs"
+        ],
+        "consumer_rule": "Current collection intake must use phases[*].current_address or all_addresses. deployment_history entries with status superseded are lineage only."
+      },
       "all_addresses": [
-        "0x6956dae88C00372B1A0b2dfBfE5Eed19F85b0D4B",
-        "0x8D4972bd5D2df474e71da6676a365fB549853991",
-        "0x77ec6B83495974a5B2C5BEf943b0f2e5aCd8Fc26",
-        "0xc557Bf6C7d21BA98A40dDfE2BEAbA682C49D17A9",
-        "0xbcb082bB41E892f29d9c600eaadEA698d5f712Ef",
-        "0x2030f226Bf9a0c88687e83AcCdcEfb7Dae260094",
-        "0xcc426F9375c5edcef5CA6bDb0449c07113348cF7",
-        "0xF68f40230E39067Ee7c98Fe9A8641fC124c5BE60",
-        "0xFc79B1BcCa172FF5a8F74205C82F5CBB0125Dd10",
-        "0xa3d3EF45712631A6Fb50c677762b8653f932cf71"
+        "0x86db98cf1b81e833447b12a077ac28c36b75c8e1",
+        "0x8d4972bd5d2df474e71da6676a365fb549853991",
+        "0x144b27b1a267ee71989664b3907030da84cc4754",
+        "0x72db992e18a1bf38111b1936dd723e82d0d96313",
+        "0x3a00301b713be83ec54b7b4fb0f86397d087e6d3",
+        "0x419f25c4f9a9c730aacf58b8401b5b3e566fe886",
+        "0x81a27117bd894942ba6737402fb9e57e942c6058",
+        "0xaab7b4502251ae393d0590bab3e208e2d58f4813",
+        "0xc64126ea8dc7626c16daa2a29d375c33fcaa4c7c",
+        "0x24f4047d372139de8dacbe79e2fc576291ec3ffc"
+      ],
+      "phases": [
+        {
+          "phase": 1,
+          "name": "MiParcels",
+          "status": "active",
+          "current_address": "0x86db98cf1b81e833447b12a077ac28c36b75c8e1"
+        },
+        {
+          "phase": 2,
+          "name": "Miladies",
+          "status": "active",
+          "current_address": "0x8d4972bd5d2df474e71da6676a365fb549853991"
+        },
+        {
+          "phase": 3,
+          "name": "MiReveal #1.1",
+          "status": "active",
+          "current_address": "0x144b27b1a267ee71989664b3907030da84cc4754"
+        },
+        {
+          "phase": 4,
+          "name": "MiReveal #2.2",
+          "status": "active",
+          "current_address": "0x72db992e18a1bf38111b1936dd723e82d0d96313"
+        },
+        {
+          "phase": 5,
+          "name": "MiReveal #3.3",
+          "status": "active",
+          "current_address": "0x3a00301b713be83ec54b7b4fb0f86397d087e6d3"
+        },
+        {
+          "phase": 6,
+          "name": "MiReveal #4.20",
+          "status": "active",
+          "current_address": "0x419f25c4f9a9c730aacf58b8401b5b3e566fe886"
+        },
+        {
+          "phase": 7,
+          "name": "MiReveal #5.5",
+          "status": "active",
+          "current_address": "0x81a27117bd894942ba6737402fb9e57e942c6058"
+        },
+        {
+          "phase": 8,
+          "name": "MiReveal #6.9",
+          "status": "active",
+          "current_address": "0xaab7b4502251ae393d0590bab3e208e2d58f4813"
+        },
+        {
+          "phase": 9,
+          "name": "MiReveal #7.7",
+          "status": "active",
+          "current_address": "0xc64126ea8dc7626c16daa2a29d375c33fcaa4c7c"
+        },
+        {
+          "phase": 10,
+          "name": "MiReveal #8.8",
+          "status": "active",
+          "current_address": "0x24f4047d372139de8dacbe79e2fc576291ec3ffc"
+        }
+      ],
+      "deployment_history": [
+        {
+          "phase": 1,
+          "address": "0x6956dae88c00372b1a0b2dfbfe5eed19f85b0d4b",
+          "status": "superseded",
+          "superseded_by": "0x86db98cf1b81e833447b12a077ac28c36b75c8e1",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 3,
+          "address": "0x77ec6b83495974a5b2c5bef943b0f2e5acd8fc26",
+          "status": "superseded",
+          "superseded_by": "0x144b27b1a267ee71989664b3907030da84cc4754",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 4,
+          "address": "0xc557bf6c7d21ba98a40ddfe2beaba682c49d17a9",
+          "status": "superseded",
+          "superseded_by": "0x72db992e18a1bf38111b1936dd723e82d0d96313",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 5,
+          "address": "0xbcb082bb41e892f29d9c600eaadea698d5f712ef",
+          "status": "superseded",
+          "superseded_by": "0x3a00301b713be83ec54b7b4fb0f86397d087e6d3",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 6,
+          "address": "0x2030f226bf9a0c88687e83accdcefb7dae260094",
+          "status": "superseded",
+          "superseded_by": "0x419f25c4f9a9c730aacf58b8401b5b3e566fe886",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 7,
+          "address": "0xcc426f9375c5edcef5ca6bdb0449c07113348cf7",
+          "status": "superseded",
+          "superseded_by": "0x81a27117bd894942ba6737402fb9e57e942c6058",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 8,
+          "address": "0xf68f40230e39067ee7c98fe9a8641fc124c5be60",
+          "status": "superseded",
+          "superseded_by": "0xaab7b4502251ae393d0590bab3e208e2d58f4813",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 9,
+          "address": "0xfc79b1bcca172ff5a8f74205c82f5cbb0125dd10",
+          "status": "superseded",
+          "superseded_by": "0xc64126ea8dc7626c16daa2a29d375c33fcaa4c7c",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 10,
+          "address": "0xa3d3ef45712631a6fb50c677762b8653f932cf71",
+          "status": "superseded",
+          "superseded_by": "0x24f4047d372139de8dacbe79e2fc576291ec3ffc",
+          "transfer_log_count": 0
+        }
       ]
     }
   ]

--- a/_codex/data/fractured-mibera.md
+++ b/_codex/data/fractured-mibera.md
@@ -8,20 +8,40 @@ FracturedMibera is a set of 10 soulbound (non-transferable) NFT collections on B
 
 Tokens cannot be transferred, approved, or burned after minting. They are permanently bound to the minting wallet.
 
-## Contracts
+## Current Contracts
 
-| # | Address | Chain |
-|---|---------|-------|
-| 1 | `0x6956dae88C00372B1A0b2dfBfE5Eed19F85b0D4B` | Berachain |
-| 2 | `0x8D4972bd5D2df474e71da6676a365fB549853991` | Berachain |
-| 3 | `0x77ec6B83495974a5B2C5BEf943b0f2e5aCd8Fc26` | Berachain |
-| 4 | `0xc557Bf6C7d21BA98A40dDfE2BEAbA682C49D17A9` | Berachain |
-| 5 | `0xbcb082bB41E892f29d9c600eaadEA698d5f712Ef` | Berachain |
-| 6 | `0x2030f226Bf9a0c88687e83AcCdcEfb7Dae260094` | Berachain |
-| 7 | `0xcc426F9375c5edcef5CA6bDb0449c07113348cF7` | Berachain |
-| 8 | `0xF68f40230E39067Ee7c98Fe9A8641fC124c5BE60` | Berachain |
-| 9 | `0xFc79B1BcCa172FF5a8F74205C82F5CBB0125Dd10` | Berachain |
-| 10 | `0xa3d3EF45712631A6Fb50c677762b8653f932cf71` | Berachain |
+| # | Address | Chain | Status |
+|---|---------|-------|--------|
+| 1 | `0x86db98cf1b81e833447b12a077ac28c36b75c8e1` | Berachain | active |
+| 2 | `0x8d4972bd5d2df474e71da6676a365fb549853991` | Berachain | active |
+| 3 | `0x144b27b1a267ee71989664b3907030da84cc4754` | Berachain | active |
+| 4 | `0x72db992e18a1bf38111b1936dd723e82d0d96313` | Berachain | active |
+| 5 | `0x3a00301b713be83ec54b7b4fb0f86397d087e6d3` | Berachain | active |
+| 6 | `0x419f25c4f9a9c730aacf58b8401b5b3e566fe886` | Berachain | active |
+| 7 | `0x81a27117bd894942ba6737402fb9e57e942c6058` | Berachain | active |
+| 8 | `0xaab7b4502251ae393d0590bab3e208e2d58f4813` | Berachain | active |
+| 9 | `0xc64126ea8dc7626c16daa2a29d375c33fcaa4c7c` | Berachain | active |
+| 10 | `0x24f4047d372139de8dacbe79e2fc576291ec3ffc` | Berachain | active |
+
+For machine consumption, `_codex/data/contracts.json` is authoritative: select `phases[*].current_address` or `all_addresses`. Do not select `deployment_history` records marked `superseded`.
+
+### Deployment Lineage
+
+An initial deployment batch preceded the active replacements by about 16 minutes. The nine first-batch contracts below have zero Transfer logs and are retained only as historical lineage. Phase 2 was not replaced.
+
+| Phase | Historical Address | Status | Superseded By |
+|-------|--------------------|--------|---------------|
+| 1 | `0x6956dae88c00372b1a0b2dfbfe5eed19f85b0d4b` | superseded | `0x86db98cf1b81e833447b12a077ac28c36b75c8e1` |
+| 3 | `0x77ec6b83495974a5b2c5bef943b0f2e5acd8fc26` | superseded | `0x144b27b1a267ee71989664b3907030da84cc4754` |
+| 4 | `0xc557bf6c7d21ba98a40ddfe2beaba682c49d17a9` | superseded | `0x72db992e18a1bf38111b1936dd723e82d0d96313` |
+| 5 | `0xbcb082bb41e892f29d9c600eaadea698d5f712ef` | superseded | `0x3a00301b713be83ec54b7b4fb0f86397d087e6d3` |
+| 6 | `0x2030f226bf9a0c88687e83accdcefb7dae260094` | superseded | `0x419f25c4f9a9c730aacf58b8401b5b3e566fe886` |
+| 7 | `0xcc426f9375c5edcef5ca6bdb0449c07113348cf7` | superseded | `0x81a27117bd894942ba6737402fb9e57e942c6058` |
+| 8 | `0xf68f40230e39067ee7c98fe9a8641fc124c5be60` | superseded | `0xaab7b4502251ae393d0590bab3e208e2d58f4813` |
+| 9 | `0xfc79b1bcca172ff5a8f74205c82f5cbb0125dd10` | superseded | `0xc64126ea8dc7626c16daa2a29d375c33fcaa4c7c` |
+| 10 | `0xa3d3ef45712631a6fb50c677762b8653f932cf71` | superseded | `0x24f4047d372139de8dacbe79e2fc576291ec3ffc` |
+
+Lineage was verified on 2026-07-18 from the deployer nonce sequence, identical runtime bytecode, and Transfer-log activity. Source: [mibera-contracts#2](https://github.com/0xHoneyJar/mibera-contracts/issues/2).
 
 All contracts reference the main Mibera collection at `0x6666397DFe9a8c469BF65dc744CB1C733416c420`.
 
@@ -50,7 +70,7 @@ function mint(uint256[] calldata tokenIds) external payable
 
 ## Deployment
 
-All 10 collections were deployed from a single script (`DeployFractured.s.sol`) that reads configuration from `fracturedData.json`:
+The collections were deployed from a single script (`DeployFractured.s.sol`) that reads configuration from `fracturedData.json`. Nine first-batch deployments were superseded by the current replacements listed above:
 - Collection names and symbols
 - Shared mint price
 - Reference to main Mibera contract address

--- a/_codex/scripts/generate-parcels.py
+++ b/_codex/scripts/generate-parcels.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 IPFS_CID = "bafybeiexd3lj53j4gpm7rcvnvprlfaa5kqj7bi4zlh4tlj5og23j6fyese"
 S3_BASE = "https://assets.0xhoneyjar.xyz/parcels/parcelsImages"
-CONTRACT = "0x6956dae88C00372B1A0b2dfBfE5Eed19F85b0D4B"
+CONTRACT = "0x86db98cf1b81e833447b12a077ac28c36b75c8e1"
 
 # Trait key normalization: source trait_type -> frontmatter key
 KEY_MAP = {

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,7 @@
     "build-onchain-data": "node scripts/build-onchain-data.mjs",
     "check-routes": "node scripts/check-routes.mjs",
     "check-contracts": "node scripts/check-contracts.mjs",
+    "test:contracts": "node --test scripts/check-contracts.test.mjs",
     "build-indexes": "node scripts/build-vault-index.mjs && node scripts/build-miberas-browse.mjs && node scripts/build-ancestors-index.mjs && node scripts/check-contracts.mjs && node scripts/build-onchain-data.mjs",
     "dev": "pnpm check-routes && pnpm build-indexes && vocs dev",
     "build": "pnpm check-routes && pnpm build-indexes && vocs build",

--- a/docs/public/contracts.json
+++ b/docs/public/contracts.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.0",
-  "generated": "2026-02-18",
+  "version": "1.1.0",
+  "generated": "2026-07-18",
   "note": "There is NO on-chain distinction between generative Miberas and hand-drawn Grails. The codex is the only layer that knows which token IDs are 1/1s.",
   "contracts": [
     {
@@ -86,22 +86,163 @@
     },
     {
       "name": "FracturedMibera",
-      "address": "0x6956dae88C00372B1A0b2dfBfE5Eed19F85b0D4B",
+      "address": "0x86db98cf1b81e833447b12a077ac28c36b75c8e1",
       "chain": "berachain",
       "chain_id": 80094,
       "standard": "ERC-721 (soulbound)",
-      "notes": "10 soulbound companion collections. Token IDs mirror main Mibera. First of 10 contracts listed.",
+      "status": "active",
+      "registry_status": "verified_current",
+      "notes": "10 active soulbound companion collections. Token IDs mirror main Mibera. The address field is the current phase 1 contract; use phases or all_addresses for the complete current set.",
+      "provenance": {
+        "source_repository": "0xHoneyJar/mibera-contracts",
+        "source_issue": "https://github.com/0xHoneyJar/mibera-contracts/issues/2",
+        "codex_issue": "https://github.com/0xHoneyJar/construct-mibera-codex/issues/94",
+        "verified_at": "2026-07-18",
+        "verification_basis": [
+          "same deployer and ordered replacement nonces",
+          "identical runtime bytecode between superseded and current pairs",
+          "current replacements contain mint/Transfer activity while superseded contracts contain zero Transfer logs"
+        ],
+        "consumer_rule": "Current collection intake must use phases[*].current_address or all_addresses. deployment_history entries with status superseded are lineage only."
+      },
       "all_addresses": [
-        "0x6956dae88C00372B1A0b2dfBfE5Eed19F85b0D4B",
-        "0x8D4972bd5D2df474e71da6676a365fB549853991",
-        "0x77ec6B83495974a5B2C5BEf943b0f2e5aCd8Fc26",
-        "0xc557Bf6C7d21BA98A40dDfE2BEAbA682C49D17A9",
-        "0xbcb082bB41E892f29d9c600eaadEA698d5f712Ef",
-        "0x2030f226Bf9a0c88687e83AcCdcEfb7Dae260094",
-        "0xcc426F9375c5edcef5CA6bDb0449c07113348cF7",
-        "0xF68f40230E39067Ee7c98Fe9A8641fC124c5BE60",
-        "0xFc79B1BcCa172FF5a8F74205C82F5CBB0125Dd10",
-        "0xa3d3EF45712631A6Fb50c677762b8653f932cf71"
+        "0x86db98cf1b81e833447b12a077ac28c36b75c8e1",
+        "0x8d4972bd5d2df474e71da6676a365fb549853991",
+        "0x144b27b1a267ee71989664b3907030da84cc4754",
+        "0x72db992e18a1bf38111b1936dd723e82d0d96313",
+        "0x3a00301b713be83ec54b7b4fb0f86397d087e6d3",
+        "0x419f25c4f9a9c730aacf58b8401b5b3e566fe886",
+        "0x81a27117bd894942ba6737402fb9e57e942c6058",
+        "0xaab7b4502251ae393d0590bab3e208e2d58f4813",
+        "0xc64126ea8dc7626c16daa2a29d375c33fcaa4c7c",
+        "0x24f4047d372139de8dacbe79e2fc576291ec3ffc"
+      ],
+      "phases": [
+        {
+          "phase": 1,
+          "name": "MiParcels",
+          "status": "active",
+          "current_address": "0x86db98cf1b81e833447b12a077ac28c36b75c8e1"
+        },
+        {
+          "phase": 2,
+          "name": "Miladies",
+          "status": "active",
+          "current_address": "0x8d4972bd5d2df474e71da6676a365fb549853991"
+        },
+        {
+          "phase": 3,
+          "name": "MiReveal #1.1",
+          "status": "active",
+          "current_address": "0x144b27b1a267ee71989664b3907030da84cc4754"
+        },
+        {
+          "phase": 4,
+          "name": "MiReveal #2.2",
+          "status": "active",
+          "current_address": "0x72db992e18a1bf38111b1936dd723e82d0d96313"
+        },
+        {
+          "phase": 5,
+          "name": "MiReveal #3.3",
+          "status": "active",
+          "current_address": "0x3a00301b713be83ec54b7b4fb0f86397d087e6d3"
+        },
+        {
+          "phase": 6,
+          "name": "MiReveal #4.20",
+          "status": "active",
+          "current_address": "0x419f25c4f9a9c730aacf58b8401b5b3e566fe886"
+        },
+        {
+          "phase": 7,
+          "name": "MiReveal #5.5",
+          "status": "active",
+          "current_address": "0x81a27117bd894942ba6737402fb9e57e942c6058"
+        },
+        {
+          "phase": 8,
+          "name": "MiReveal #6.9",
+          "status": "active",
+          "current_address": "0xaab7b4502251ae393d0590bab3e208e2d58f4813"
+        },
+        {
+          "phase": 9,
+          "name": "MiReveal #7.7",
+          "status": "active",
+          "current_address": "0xc64126ea8dc7626c16daa2a29d375c33fcaa4c7c"
+        },
+        {
+          "phase": 10,
+          "name": "MiReveal #8.8",
+          "status": "active",
+          "current_address": "0x24f4047d372139de8dacbe79e2fc576291ec3ffc"
+        }
+      ],
+      "deployment_history": [
+        {
+          "phase": 1,
+          "address": "0x6956dae88c00372b1a0b2dfbfe5eed19f85b0d4b",
+          "status": "superseded",
+          "superseded_by": "0x86db98cf1b81e833447b12a077ac28c36b75c8e1",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 3,
+          "address": "0x77ec6b83495974a5b2c5bef943b0f2e5acd8fc26",
+          "status": "superseded",
+          "superseded_by": "0x144b27b1a267ee71989664b3907030da84cc4754",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 4,
+          "address": "0xc557bf6c7d21ba98a40ddfe2beaba682c49d17a9",
+          "status": "superseded",
+          "superseded_by": "0x72db992e18a1bf38111b1936dd723e82d0d96313",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 5,
+          "address": "0xbcb082bb41e892f29d9c600eaadea698d5f712ef",
+          "status": "superseded",
+          "superseded_by": "0x3a00301b713be83ec54b7b4fb0f86397d087e6d3",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 6,
+          "address": "0x2030f226bf9a0c88687e83accdcefb7dae260094",
+          "status": "superseded",
+          "superseded_by": "0x419f25c4f9a9c730aacf58b8401b5b3e566fe886",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 7,
+          "address": "0xcc426f9375c5edcef5ca6bdb0449c07113348cf7",
+          "status": "superseded",
+          "superseded_by": "0x81a27117bd894942ba6737402fb9e57e942c6058",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 8,
+          "address": "0xf68f40230e39067ee7c98fe9a8641fc124c5be60",
+          "status": "superseded",
+          "superseded_by": "0xaab7b4502251ae393d0590bab3e208e2d58f4813",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 9,
+          "address": "0xfc79b1bcca172ff5a8f74205c82f5cbb0125dd10",
+          "status": "superseded",
+          "superseded_by": "0xc64126ea8dc7626c16daa2a29d375c33fcaa4c7c",
+          "transfer_log_count": 0
+        },
+        {
+          "phase": 10,
+          "address": "0xa3d3ef45712631a6fb50c677762b8653f932cf71",
+          "status": "superseded",
+          "superseded_by": "0x24f4047d372139de8dacbe79e2fc576291ec3ffc",
+          "transfer_log_count": 0
+        }
       ]
     }
   ]

--- a/docs/scripts/check-contracts.mjs
+++ b/docs/scripts/check-contracts.mjs
@@ -11,6 +11,10 @@
  *   - Chain field is present (every row carries chain metadata)
  *   - Duplicate addresses are detected (same address listed twice = error)
  *   - Required name + standard fields are present
+ *   - FracturedMibera current phases are complete, unique, and cannot resolve
+ *     to a superseded zero-Transfer deployment
+ *   - FracturedMibera lineage carries explicit superseded_by relationships
+ *     and verification provenance
  *
  * NOT validated here (intentional, future hardening):
  *   - EIP-55 checksum verification (requires keccak-256; deferred to
@@ -24,66 +28,242 @@
 
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..", "..");
 const CONTRACTS_PATH = path.join(ROOT, "_codex", "data", "contracts.json");
 
-console.log(`[check-contracts] resolved repo root: ${ROOT}`);
-
 const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
 
-const raw = await readFile(CONTRACTS_PATH, "utf8");
-let parsed;
-try {
-  parsed = JSON.parse(raw);
-} catch (err) {
-  console.error(`[check-contracts] ✘ invalid JSON in ${CONTRACTS_PATH}`);
-  console.error(`  ${err.message}`);
-  process.exit(1);
+function lower(address) {
+  return typeof address === "string" ? address.toLowerCase() : address;
 }
 
-if (!Array.isArray(parsed.contracts)) {
-  console.error(
-    `[check-contracts] ✘ contracts.json missing top-level 'contracts' array`
-  );
-  process.exit(1);
-}
+function validateFracturedMibera(fractures, errors) {
+  const tag = '"FracturedMibera"';
 
-const errors = [];
-const seenAddresses = new Map(); // address (lowercase) → first row index
+  if (fractures.status !== "active") {
+    errors.push(`${tag}: status must be 'active'`);
+  }
+  if (fractures.registry_status !== "verified_current") {
+    errors.push(`${tag}: registry_status must be 'verified_current'`);
+  }
 
-parsed.contracts.forEach((c, idx) => {
-  const tag = c.name ? `"${c.name}"` : `row ${idx}`;
-  if (!c.name) errors.push(`${tag}: missing required field 'name'`);
-  if (!c.address) {
-    errors.push(`${tag}: missing required field 'address'`);
-  } else {
-    if (!ADDRESS_REGEX.test(c.address)) {
-      errors.push(`${tag}: address '${c.address}' fails regex ${ADDRESS_REGEX}`);
-    }
-    const lc = c.address.toLowerCase();
-    if (seenAddresses.has(lc)) {
-      const firstIdx = seenAddresses.get(lc);
-      const firstName = parsed.contracts[firstIdx]?.name ?? `row ${firstIdx}`;
-      errors.push(
-        `${tag}: duplicate address ${c.address} (also used by "${firstName}")`
-      );
-    } else {
-      seenAddresses.set(lc, idx);
+  const provenance = fractures.provenance;
+  for (const field of [
+    "source_repository",
+    "source_issue",
+    "verified_at",
+    "consumer_rule",
+  ]) {
+    if (!provenance?.[field]) {
+      errors.push(`${tag}: provenance.${field} is required`);
     }
   }
-  if (!c.chain) errors.push(`${tag}: missing required field 'chain'`);
-  if (!c.standard) errors.push(`${tag}: missing required field 'standard'`);
-});
+  if (
+    !Array.isArray(provenance?.verification_basis) ||
+    provenance.verification_basis.length === 0
+  ) {
+    errors.push(`${tag}: provenance.verification_basis must be non-empty`);
+  }
 
-if (errors.length > 0) {
-  console.error(`[check-contracts] ✘ ${errors.length} validation error(s):`);
-  for (const e of errors) console.error(`  ${e}`);
-  process.exit(1);
+  if (!Array.isArray(fractures.phases)) {
+    errors.push(`${tag}: phases must be an array`);
+    return;
+  }
+
+  const phaseNumbers = fractures.phases.map((phase) => phase.phase);
+  const expectedPhaseNumbers = Array.from({ length: 10 }, (_, idx) => idx + 1);
+  if (
+    phaseNumbers.length !== expectedPhaseNumbers.length ||
+    !phaseNumbers.every((phase, idx) => phase === expectedPhaseNumbers[idx])
+  ) {
+    errors.push(`${tag}: phases must be ordered exactly 1 through 10`);
+  }
+
+  const activeAddresses = [];
+  const seenActiveAddresses = new Set();
+  for (const phase of fractures.phases) {
+    const phaseTag = `${tag} phase ${phase.phase ?? "unknown"}`;
+    if (phase.status !== "active") {
+      errors.push(`${phaseTag}: status must be 'active'`);
+    }
+    if (!ADDRESS_REGEX.test(phase.current_address ?? "")) {
+      errors.push(`${phaseTag}: current_address is missing or malformed`);
+      continue;
+    }
+    const address = lower(phase.current_address);
+    if (seenActiveAddresses.has(address)) {
+      errors.push(`${phaseTag}: duplicate current_address ${phase.current_address}`);
+    }
+    seenActiveAddresses.add(address);
+    activeAddresses.push(address);
+  }
+
+  if (!Array.isArray(fractures.all_addresses)) {
+    errors.push(`${tag}: all_addresses must be an array`);
+  } else {
+    const allAddresses = fractures.all_addresses.map(lower);
+    if (
+      allAddresses.length !== activeAddresses.length ||
+      !allAddresses.every((address, idx) => address === activeAddresses[idx])
+    ) {
+      errors.push(
+        `${tag}: all_addresses must exactly match phases[*].current_address in phase order`
+      );
+    }
+  }
+
+  if (lower(fractures.address) !== activeAddresses[0]) {
+    errors.push(`${tag}: address must equal the current phase 1 address`);
+  }
+
+  if (!Array.isArray(fractures.deployment_history)) {
+    errors.push(`${tag}: deployment_history must be an array`);
+    return;
+  }
+
+  const historyByPhase = new Map();
+  const supersededAddresses = new Set();
+  for (const record of fractures.deployment_history) {
+    const historyTag = `${tag} deployment_history phase ${record.phase ?? "unknown"}`;
+    if (record.status !== "superseded") {
+      errors.push(`${historyTag}: status must be 'superseded'`);
+    }
+    if (record.transfer_log_count !== 0) {
+      errors.push(`${historyTag}: transfer_log_count must be 0`);
+    }
+    if (!ADDRESS_REGEX.test(record.address ?? "")) {
+      errors.push(`${historyTag}: address is missing or malformed`);
+      continue;
+    }
+    if (!ADDRESS_REGEX.test(record.superseded_by ?? "")) {
+      errors.push(`${historyTag}: superseded_by is missing or malformed`);
+      continue;
+    }
+
+    const historicalAddress = lower(record.address);
+    const supersededBy = lower(record.superseded_by);
+    if (supersededAddresses.has(historicalAddress)) {
+      errors.push(`${historyTag}: duplicate historical address ${record.address}`);
+    }
+    supersededAddresses.add(historicalAddress);
+
+    if (seenActiveAddresses.has(historicalAddress)) {
+      errors.push(
+        `${historyTag}: superseded address ${record.address} cannot be selected as current`
+      );
+    }
+
+    const currentPhase = fractures.phases.find(
+      (phase) => phase.phase === record.phase
+    );
+    if (!currentPhase) {
+      errors.push(`${historyTag}: no matching current phase`);
+    } else if (lower(currentPhase.current_address) !== supersededBy) {
+      errors.push(
+        `${historyTag}: superseded_by must equal phase ${record.phase} current_address`
+      );
+    }
+
+    historyByPhase.set(
+      record.phase,
+      (historyByPhase.get(record.phase) ?? 0) + 1
+    );
+  }
+
+  for (const phase of expectedPhaseNumbers) {
+    const expectedHistoryCount = phase === 2 ? 0 : 1;
+    const actualHistoryCount = historyByPhase.get(phase) ?? 0;
+    if (actualHistoryCount !== expectedHistoryCount) {
+      errors.push(
+        `${tag}: phase ${phase} must have ${expectedHistoryCount} superseded history record(s), found ${actualHistoryCount}`
+      );
+    }
+  }
 }
 
-console.log(
-  `[check-contracts] ✔ ${parsed.contracts.length} contracts validated (address shape, chain required, no duplicates)`
-);
+export function validateContractRegistry(parsed) {
+  const errors = [];
+  if (!Array.isArray(parsed?.contracts)) {
+    return [`contracts.json missing top-level 'contracts' array`];
+  }
+
+  const seenAddresses = new Map(); // address (lowercase) → first row index
+
+  parsed.contracts.forEach((contract, idx) => {
+    const tag = contract.name ? `"${contract.name}"` : `row ${idx}`;
+    if (!contract.name) errors.push(`${tag}: missing required field 'name'`);
+    if (!contract.address) {
+      errors.push(`${tag}: missing required field 'address'`);
+    } else {
+      if (!ADDRESS_REGEX.test(contract.address)) {
+        errors.push(
+          `${tag}: address '${contract.address}' fails regex ${ADDRESS_REGEX}`
+        );
+      }
+      const address = lower(contract.address);
+      if (seenAddresses.has(address)) {
+        const firstIdx = seenAddresses.get(address);
+        const firstName =
+          parsed.contracts[firstIdx]?.name ?? `row ${firstIdx}`;
+        errors.push(
+          `${tag}: duplicate address ${contract.address} (also used by "${firstName}")`
+        );
+      } else {
+        seenAddresses.set(address, idx);
+      }
+    }
+    if (!contract.chain) errors.push(`${tag}: missing required field 'chain'`);
+    if (!contract.standard) {
+      errors.push(`${tag}: missing required field 'standard'`);
+    }
+  });
+
+  const fractureRows = parsed.contracts.filter(
+    (contract) => contract.name === "FracturedMibera"
+  );
+  if (fractureRows.length !== 1) {
+    errors.push(
+      `contracts.json must contain exactly one FracturedMibera row, found ${fractureRows.length}`
+    );
+  } else {
+    validateFracturedMibera(fractureRows[0], errors);
+  }
+
+  return errors;
+}
+
+async function main() {
+  console.log(`[check-contracts] resolved repo root: ${ROOT}`);
+  const raw = await readFile(CONTRACTS_PATH, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    console.error(`[check-contracts] ✘ invalid JSON in ${CONTRACTS_PATH}`);
+    console.error(`  ${err.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const errors = validateContractRegistry(parsed);
+  if (errors.length > 0) {
+    console.error(`[check-contracts] ✘ ${errors.length} validation error(s):`);
+    for (const error of errors) console.error(`  ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `[check-contracts] ✔ ${parsed.contracts.length} contracts validated (address shape, chain required, no duplicates, FracturedMibera active-lineage invariants)`
+  );
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : null;
+if (invokedPath === import.meta.url) {
+  await main();
+}

--- a/docs/scripts/check-contracts.test.mjs
+++ b/docs/scripts/check-contracts.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { validateContractRegistry } from "./check-contracts.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const contractsPath = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "_codex",
+  "data",
+  "contracts.json"
+);
+const registry = JSON.parse(await readFile(contractsPath, "utf8"));
+const fractureFiles = [
+  "miparcels.md",
+  "miladies.md",
+  "mireveal-1.1.md",
+  "mireveal-2.2.md",
+  "mireveal-3.3.md",
+  "mireveal-4.20.md",
+  "mireveal-5.5.md",
+  "mireveal-6.9.md",
+  "mireveal-7.7.md",
+  "mireveal-8.8.md",
+];
+
+function cloneRegistry() {
+  return structuredClone(registry);
+}
+
+function fracturedMibera(candidate) {
+  return candidate.contracts.find(
+    (contract) => contract.name === "FracturedMibera"
+  );
+}
+
+test("accepts the verified current FracturedMibera registry", () => {
+  assert.deepEqual(validateContractRegistry(cloneRegistry()), []);
+});
+
+test("phase documents select only verified current registry addresses", async () => {
+  const documentedAddresses = await Promise.all(
+    fractureFiles.map(async (file) => {
+      const body = await readFile(
+        path.resolve(__dirname, "..", "..", "fractures", file),
+        "utf8"
+      );
+      const address = body.match(/^contract: "([^"]+)"$/m)?.[1];
+      assert.ok(address, `${file} must declare a contract`);
+      return address.toLowerCase();
+    })
+  );
+  const currentAddresses = fracturedMibera(registry).phases.map((phase) =>
+    phase.current_address.toLowerCase()
+  );
+
+  assert.deepEqual(documentedAddresses, currentAddresses);
+});
+
+test("rejects a superseded zero-Transfer deployment selected as current", () => {
+  const candidate = cloneRegistry();
+  const fractures = fracturedMibera(candidate);
+  const superseded = fractures.deployment_history[0].address;
+
+  fractures.address = superseded;
+  fractures.all_addresses[0] = superseded;
+  fractures.phases[0].current_address = superseded;
+
+  const errors = validateContractRegistry(candidate);
+  assert.ok(
+    errors.some((error) =>
+      error.includes("superseded address") && error.includes("cannot be selected")
+    ),
+    errors.join("\n")
+  );
+});
+
+test("rejects lineage whose superseded_by does not resolve to current", () => {
+  const candidate = cloneRegistry();
+  const fractures = fracturedMibera(candidate);
+  fractures.deployment_history[0].superseded_by =
+    fractures.phases[2].current_address;
+
+  const errors = validateContractRegistry(candidate);
+  assert.ok(
+    errors.some((error) =>
+      error.includes("superseded_by must equal phase 1 current_address")
+    ),
+    errors.join("\n")
+  );
+});
+
+test("rejects a registry without verification provenance", () => {
+  const candidate = cloneRegistry();
+  delete fracturedMibera(candidate).provenance.source_issue;
+
+  const errors = validateContractRegistry(candidate);
+  assert.ok(
+    errors.includes('"FracturedMibera": provenance.source_issue is required'),
+    errors.join("\n")
+  );
+});

--- a/fractures/README.md
+++ b/fractures/README.md
@@ -1,4 +1,4 @@
-<!-- codex-status: COMPLETE | entities: 10 | last-verified: 2026-02-18 -->
+<!-- codex-status: COMPLETE | entities: 10 | last-verified: 2026-07-18 -->
 # Fractures — The Reveal Timeline
 
 *10 soulbound collections marking each phase of Mibera's emergence into the world.*
@@ -32,22 +32,42 @@ The reveal unfolds in 10 stages. The first two phases — MiParcels and Miladies
 
 The decimal numbering is playful and intentional: 1.1, 2.2, 3.3, **4.20**, 5.5, **6.9**, 7.7, 8.8. The cultural references in 4.20 and 6.9 are deliberate.
 
-## Contracts
+## Current Contracts
 
-All 10 Fracture collections are soulbound ERC-721 contracts on Berachain, deployed from a single script. Token IDs mirror the main Mibera collection 1:1.
+All 10 Fracture collections are soulbound ERC-721 contracts on Berachain. Token IDs mirror the main Mibera collection 1:1.
 
-| # | Name | Contract |
-|---|------|----------|
-| 1 | MiParcels | `0x6956dae88C00372B1A0b2dfBfE5Eed19F85b0D4B` |
-| 2 | Miladies | `0x8D4972bd5D2df474e71da6676a365fB549853991` |
-| 3 | MiReveal #1.1 | `0x77ec6B83495974a5B2C5BEf943b0f2e5aCd8Fc26` |
-| 4 | MiReveal #2.2 | `0xc557Bf6C7d21BA98A40dDfE2BEAbA682C49D17A9` |
-| 5 | MiReveal #3.3 | `0xbcb082bB41E892f29d9c600eaadEA698d5f712Ef` |
-| 6 | MiReveal #4.20 | `0x2030f226Bf9a0c88687e83AcCdcEfb7Dae260094` |
-| 7 | MiReveal #5.5 | `0xcc426F9375c5edcef5CA6bDb0449c07113348cF7` |
-| 8 | MiReveal #6.9 | `0xF68f40230E39067Ee7c98Fe9A8641fC124c5BE60` |
-| 9 | MiReveal #7.7 | `0xFc79B1BcCa172FF5a8F74205C82F5CBB0125Dd10` |
-| 10 | MiReveal #8.8 | `0xa3d3EF45712631A6Fb50c677762b8653f932cf71` |
+Use this table, or `_codex/data/contracts.json` → `FracturedMibera.phases[*].current_address`, for current collection intake. Historical contracts marked `superseded` below are lineage evidence, not active collections.
+
+| # | Name | Current Contract | Status |
+|---|------|------------------|--------|
+| 1 | MiParcels | `0x86db98cf1b81e833447b12a077ac28c36b75c8e1` | active |
+| 2 | Miladies | `0x8d4972bd5d2df474e71da6676a365fb549853991` | active |
+| 3 | MiReveal #1.1 | `0x144b27b1a267ee71989664b3907030da84cc4754` | active |
+| 4 | MiReveal #2.2 | `0x72db992e18a1bf38111b1936dd723e82d0d96313` | active |
+| 5 | MiReveal #3.3 | `0x3a00301b713be83ec54b7b4fb0f86397d087e6d3` | active |
+| 6 | MiReveal #4.20 | `0x419f25c4f9a9c730aacf58b8401b5b3e566fe886` | active |
+| 7 | MiReveal #5.5 | `0x81a27117bd894942ba6737402fb9e57e942c6058` | active |
+| 8 | MiReveal #6.9 | `0xaab7b4502251ae393d0590bab3e208e2d58f4813` | active |
+| 9 | MiReveal #7.7 | `0xc64126ea8dc7626c16daa2a29d375c33fcaa4c7c` | active |
+| 10 | MiReveal #8.8 | `0x24f4047d372139de8dacbe79e2fc576291ec3ffc` | active |
+
+### Superseded Deployment Lineage
+
+The deployer created an initial batch and then replaced nine of its ten contracts about 16 minutes later. The replacements have identical runtime bytecode and the mint/Transfer activity; the first-batch contracts below have zero Transfer logs. Phase 2 was not replaced.
+
+| Phase | Historical Contract | Status | Superseded By |
+|-------|---------------------|--------|---------------|
+| 1 | `0x6956dae88c00372b1a0b2dfbfe5eed19f85b0d4b` | superseded (0 Transfer logs) | `0x86db98cf1b81e833447b12a077ac28c36b75c8e1` |
+| 3 | `0x77ec6b83495974a5b2c5bef943b0f2e5acd8fc26` | superseded (0 Transfer logs) | `0x144b27b1a267ee71989664b3907030da84cc4754` |
+| 4 | `0xc557bf6c7d21ba98a40ddfe2beaba682c49d17a9` | superseded (0 Transfer logs) | `0x72db992e18a1bf38111b1936dd723e82d0d96313` |
+| 5 | `0xbcb082bb41e892f29d9c600eaadea698d5f712ef` | superseded (0 Transfer logs) | `0x3a00301b713be83ec54b7b4fb0f86397d087e6d3` |
+| 6 | `0x2030f226bf9a0c88687e83accdcefb7dae260094` | superseded (0 Transfer logs) | `0x419f25c4f9a9c730aacf58b8401b5b3e566fe886` |
+| 7 | `0xcc426f9375c5edcef5ca6bdb0449c07113348cf7` | superseded (0 Transfer logs) | `0x81a27117bd894942ba6737402fb9e57e942c6058` |
+| 8 | `0xf68f40230e39067ee7c98fe9a8641fc124c5be60` | superseded (0 Transfer logs) | `0xaab7b4502251ae393d0590bab3e208e2d58f4813` |
+| 9 | `0xfc79b1bcca172ff5a8f74205c82f5cbb0125dd10` | superseded (0 Transfer logs) | `0xc64126ea8dc7626c16daa2a29d375c33fcaa4c7c` |
+| 10 | `0xa3d3ef45712631a6fb50c677762b8653f932cf71` | superseded (0 Transfer logs) | `0x24f4047d372139de8dacbe79e2fc576291ec3ffc` |
+
+**Provenance:** [mibera-contracts lineage correction](https://github.com/0xHoneyJar/mibera-contracts/issues/2) · [codex correction](https://github.com/0xHoneyJar/construct-mibera-codex/issues/94) · verified 2026-07-18.
 
 > **Technical details** — soulbound enforcement, minting mechanics, and deployment info: [FracturedMibera contract reference](../_codex/data/fractured-mibera.md)
 

--- a/fractures/miparcels.md
+++ b/fractures/miparcels.md
@@ -4,7 +4,7 @@ name: "MiParcels"
 type: fracture
 date: "2025-04-20"
 symbol: MIPARCEL
-contract: "0x6956dae88C00372B1A0b2dfBfE5Eed19F85b0D4B"
+contract: "0x86db98cf1b81e833447b12a077ac28c36b75c8e1"
 ---
 
 # MiParcels

--- a/fractures/mireveal-1.1.md
+++ b/fractures/mireveal-1.1.md
@@ -4,7 +4,7 @@ name: "MiReveal #1.1"
 type: fracture
 date: "2025-04-29"
 symbol: MIREVEAL1.1
-contract: "0x77ec6B83495974a5B2C5BEf943b0f2e5aCd8Fc26"
+contract: "0x144b27b1a267ee71989664b3907030da84cc4754"
 ---
 
 # MiReveal #1.1

--- a/fractures/mireveal-2.2.md
+++ b/fractures/mireveal-2.2.md
@@ -4,7 +4,7 @@ name: "MiReveal #2.2"
 type: fracture
 date: "2025-05-01"
 symbol: MIREVEAL2.2
-contract: "0xc557Bf6C7d21BA98A40dDfE2BEAbA682C49D17A9"
+contract: "0x72db992e18a1bf38111b1936dd723e82d0d96313"
 ---
 
 # MiReveal #2.2

--- a/fractures/mireveal-3.3.md
+++ b/fractures/mireveal-3.3.md
@@ -4,7 +4,7 @@ name: "MiReveal #3.3"
 type: fracture
 date: "2025-05-06"
 symbol: MIREVEAL3.3
-contract: "0xbcb082bB41E892f29d9c600eaadEA698d5f712Ef"
+contract: "0x3a00301b713be83ec54b7b4fb0f86397d087e6d3"
 ---
 
 # MiReveal #3.3

--- a/fractures/mireveal-4.20.md
+++ b/fractures/mireveal-4.20.md
@@ -4,7 +4,7 @@ name: "MiReveal #4.20"
 type: fracture
 date: "2025-05-08"
 symbol: MIREVEAL4.20
-contract: "0x2030f226Bf9a0c88687e83AcCdcEfb7Dae260094"
+contract: "0x419f25c4f9a9c730aacf58b8401b5b3e566fe886"
 ---
 
 # MiReveal #4.20

--- a/fractures/mireveal-5.5.md
+++ b/fractures/mireveal-5.5.md
@@ -4,7 +4,7 @@ name: "MiReveal #5.5"
 type: fracture
 date: "2025-05-13"
 symbol: MIREVEAL5.5
-contract: "0xcc426F9375c5edcef5CA6bDb0449c07113348cF7"
+contract: "0x81a27117bd894942ba6737402fb9e57e942c6058"
 ---
 
 # MiReveal #5.5

--- a/fractures/mireveal-6.9.md
+++ b/fractures/mireveal-6.9.md
@@ -4,7 +4,7 @@ name: "MiReveal #6.9"
 type: fracture
 date: "2025-05-15"
 symbol: MIREVEAL6.9
-contract: "0xF68f40230E39067Ee7c98Fe9A8641fC124c5BE60"
+contract: "0xaab7b4502251ae393d0590bab3e208e2d58f4813"
 ---
 
 # MiReveal #6.9

--- a/fractures/mireveal-7.7.md
+++ b/fractures/mireveal-7.7.md
@@ -4,7 +4,7 @@ name: "MiReveal #7.7"
 type: fracture
 date: "2025-05-20"
 symbol: MIREVEAL7.7
-contract: "0xFc79B1BcCa172FF5a8F74205C82F5CBB0125Dd10"
+contract: "0xc64126ea8dc7626c16daa2a29d375c33fcaa4c7c"
 ---
 
 # MiReveal #7.7

--- a/fractures/mireveal-8.8.md
+++ b/fractures/mireveal-8.8.md
@@ -4,7 +4,7 @@ name: "MiReveal #8.8"
 type: fracture
 date: "2025-06-03"
 symbol: MIREVEAL8.8
-contract: "0xa3d3EF45712631A6Fb50c677762b8653f932cf71"
+contract: "0x24f4047d372139de8dacbe79e2fc576291ec3ffc"
 ---
 
 # MiReveal #8.8

--- a/miparcels/README.md
+++ b/miparcels/README.md
@@ -21,7 +21,7 @@ Every parcel is named: **Honey Road Parcel #N from High Council 任侠団体 of 
 | Property | Value |
 |----------|-------|
 | Token Count | 10,000 |
-| Contract | `0x6956dae88C00372B1A0b2dfBfE5Eed19F85b0D4B` |
+| Contract | `0x86db98cf1b81e833447b12a077ac28c36b75c8e1` |
 | IPFS CID | `bafybeiexd3lj53j4gpm7rcvnvprlfaa5kqj7bi4zlh4tlj5og23j6fyese` |
 | Trait Categories | 15 (excl. background) |
 | Fracture Phase | Phase 1 |


### PR DESCRIPTION
## Outcome

Corrects the FracturedMibera registry so current consumers select the ten live contracts while the nine abandoned first-batch deployments remain explicit, non-consumable lineage.

Closes #94.
Related: 0xHoneyJar/mibera-contracts#2 and 0xHoneyJar/sonar-api#217.

## What changed

- promotes all ten verified-current phase addresses, including the unchanged active phase 2
- retains the nine zero-Transfer addresses only as `status: superseded` with `superseded_by`
- adds provenance and a machine-consumer rule to the canonical and published registries
- updates every current-facing Fractures/MiParcels documentation surface
- adds an inclusive deterministic validator and five regression tests

## Verification

- `pnpm --dir docs test:contracts` — 5/5
- direct contract-registry check — pass
- route, structure, link, semantic, schema, export-drift, and diff checks — pass
- independent blocker review — approved

The full repository health score still reports pre-existing graph-age and manifest-freshness drift; this patch does not modify or conceal those findings. No production/indexer mutation is included.